### PR TITLE
Added support for reading Bruker BioTyper MSP metadata

### DIFF
--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.btmsp/src/net/openchrom/msd/converter/supplier/btmsp/converter/io/BTMSPReader.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.btmsp/src/net/openchrom/msd/converter/supplier/btmsp/converter/io/BTMSPReader.java
@@ -85,7 +85,7 @@ public class BTMSPReader extends AbstractMassSpectraReader implements IMassSpect
 					libraryInformation.setName(attribute.getValue());
 				}
 			}
-			dataXML = zipFile.getInputStream(zipData); // TODO: Do I really need to reload the whole file?
+			dataXML = zipFile.getInputStream(zipData);
 			bufferedInputStream = new BufferedInputStream(dataXML);
 			eventReader = inputFactory.createXMLEventReader(bufferedInputStream);
 			eventFilter = new EventFilterSample();
@@ -106,7 +106,7 @@ public class BTMSPReader extends AbstractMassSpectraReader implements IMassSpect
 					}
 				}
 			}
-			dataXML = zipFile.getInputStream(zipData); // TODO: Do I really need to reload the whole file?
+			dataXML = zipFile.getInputStream(zipData);
 			BufferedInputStream newBufferedInputStream = new BufferedInputStream(dataXML);
 			eventReader = inputFactory.createXMLEventReader(newBufferedInputStream);
 			eventFilter = new EventFilterPeakData();

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.btmsp/src/net/openchrom/msd/converter/supplier/btmsp/converter/io/BTMSPReader.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.btmsp/src/net/openchrom/msd/converter/supplier/btmsp/converter/io/BTMSPReader.java
@@ -81,8 +81,29 @@ public class BTMSPReader extends AbstractMassSpectraReader implements IMassSpect
 				Attribute attribute = mainSpectrumAttributes.next();
 				String attributeName = attribute.getName().getLocalPart();
 				if(attributeName.equals("name")) {
-					massSpectra.setName(attribute.getValue()); // TODO: add more metadata
+					massSpectra.setName(attribute.getValue());
 					libraryInformation.setName(attribute.getValue());
+				}
+			}
+			dataXML = zipFile.getInputStream(zipData); // TODO: Do I really need to reload the whole file?
+			bufferedInputStream = new BufferedInputStream(dataXML);
+			eventReader = inputFactory.createXMLEventReader(bufferedInputStream);
+			eventFilter = new EventFilterSample();
+			filteredEventReader = inputFactory.createFilteredReader(eventReader, eventFilter);
+			if(filteredEventReader.hasNext()) {
+				xmlEvent = filteredEventReader.nextEvent();
+				@SuppressWarnings("unchecked")
+				Iterator<? extends Attribute> sampleAttributes = xmlEvent.asStartElement().getAttributes();
+				while(sampleAttributes.hasNext()) {
+					Attribute attribute = sampleAttributes.next();
+					String attributeName = attribute.getName().getLocalPart();
+					if(attributeName.equals("providedBy")) {
+						libraryInformation.setContributor(attribute.getValue());
+					} else if(attributeName.equals("comment")) {
+						libraryInformation.setComments(attribute.getValue());
+					} else if(attributeName.equals("growingConditions")) {
+						libraryInformation.setMiscellaneous(attribute.getValue());
+					}
 				}
 			}
 			dataXML = zipFile.getInputStream(zipData); // TODO: Do I really need to reload the whole file?

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.btmsp/src/net/openchrom/msd/converter/supplier/btmsp/converter/io/BTMSPReader.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.btmsp/src/net/openchrom/msd/converter/supplier/btmsp/converter/io/BTMSPReader.java
@@ -52,7 +52,6 @@ public class BTMSPReader extends AbstractMassSpectraReader implements IMassSpect
 	@Override
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
 
-		IMassSpectra massSpectra = new MassSpectra();
 		ZipFile zipFile = new ZipFile(file);
 		Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
 		ZipEntry zipData = null;
@@ -66,6 +65,7 @@ public class BTMSPReader extends AbstractMassSpectraReader implements IMassSpect
 			zipFile.close();
 			throw new FileIsNotReadableException();
 		}
+		IMassSpectra massSpectra = new MassSpectra();
 		ILibraryInformation libraryInformation = new PeakLibraryInformation();
 		try {
 			XMLInputFactory inputFactory = XMLInputFactory.newInstance();

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.btmsp/src/net/openchrom/msd/converter/supplier/btmsp/converter/io/BTMSPReader.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.btmsp/src/net/openchrom/msd/converter/supplier/btmsp/converter/io/BTMSPReader.java
@@ -33,6 +33,8 @@ import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.exceptions.AbundanceLimitExceededException;
+import org.eclipse.chemclipse.model.identifier.ILibraryInformation;
+import org.eclipse.chemclipse.model.identifier.PeakLibraryInformation;
 import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
 import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
@@ -64,6 +66,7 @@ public class BTMSPReader extends AbstractMassSpectraReader implements IMassSpect
 			zipFile.close();
 			throw new FileIsNotReadableException();
 		}
+		ILibraryInformation libraryInformation = new PeakLibraryInformation();
 		try {
 			XMLInputFactory inputFactory = XMLInputFactory.newInstance();
 			InputStream dataXML = zipFile.getInputStream(zipData); // UTF8, no BOM
@@ -79,6 +82,7 @@ public class BTMSPReader extends AbstractMassSpectraReader implements IMassSpect
 				String attributeName = attribute.getName().getLocalPart();
 				if(attributeName.equals("name")) {
 					massSpectra.setName(attribute.getValue()); // TODO: add more metadata
+					libraryInformation.setName(attribute.getValue());
 				}
 			}
 			dataXML = zipFile.getInputStream(zipData); // TODO: Do I really need to reload the whole file?
@@ -107,6 +111,7 @@ public class BTMSPReader extends AbstractMassSpectraReader implements IMassSpect
 					}
 				}
 			}
+			mainSpectrum.setLibraryInformation(libraryInformation);
 			massSpectra.addMassSpectrum(mainSpectrum);
 		} catch(XMLStreamException | AbundanceLimitExceededException
 				| IonLimitExceededException e) {

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.btmsp/src/net/openchrom/msd/converter/supplier/btmsp/converter/io/EventFilterSample.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.btmsp/src/net/openchrom/msd/converter/supplier/btmsp/converter/io/EventFilterSample.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Matthias Mailänder.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package net.openchrom.msd.converter.supplier.btmsp.converter.io;
+
+import javax.xml.stream.EventFilter;
+import javax.xml.stream.events.XMLEvent;
+
+public class EventFilterSample implements EventFilter {
+
+	private String acceptedElement;
+
+	public EventFilterSample() {
+
+		acceptedElement = "sample";
+	}
+
+	@Override
+	public boolean accept(XMLEvent xmlEvent) {
+
+		boolean result = false;
+		String element;
+		if(xmlEvent.isStartElement()) {
+			element = xmlEvent.asStartElement().getName().getLocalPart();
+			if(element.equals(acceptedElement)) {
+				result = true;
+			}
+		}
+		return result;
+	}
+}


### PR DESCRIPTION
This is a followup of https://github.com/OpenChrom/openchrom/pull/83 which also improves compatibility with https://github.com/OpenChrom/openchrom/pull/86 as it allows conversion from .btmsp to named .peaks ZIP.