### PR TITLE
Added a sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# Sponsor links
+custom: ["https://www.paypal.com/donate/?item_name=Donation+to+OpenChrom&cmd=_donations&business=philip.wenig%40openchrom.net", paypal.com]


### PR DESCRIPTION
This migrates https://sourceforge.net/p/openchrom/donate/ to this repository. See also https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository