### PR TITLE
Update GTK version to 3 on Linux

### DIFF
--- a/openchrom/products/net.openchrom.rcp.compilation.community.product/openchrom.compilation.community.product
+++ b/openchrom/products/net.openchrom.rcp.compilation.community.product/openchrom.compilation.community.product
@@ -16,9 +16,6 @@
    <launcherArgs>
       <programArgs>-clearPersistedState
       </programArgs>
-      <programArgsLin>--launcher.GTK_version
-2
-      </programArgsLin>
       <vmArgs>-Xms512M
 -Xmx1024M
 -Dosgi.framework.extensions=org.eclipse.fx.osgi


### PR DESCRIPTION
Same as https://github.com/eclipse/chemclipse/pull/701. GTK version 2.X has reached end of life with https://blog.gtk.org/2020/12/16/gtk-4-0/