### PR TITLE
Disable object deserialization for multi line string settings

### DIFF
--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/settings/CompensationQuantifierSettings.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/settings/CompensationQuantifierSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Lablicate GmbH.
+ * Copyright (c) 2019, 2021 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,7 @@ import org.eclipse.chemclipse.chromatogram.msd.quantitation.settings.AbstractPea
 import org.eclipse.chemclipse.support.settings.StringSettingsProperty;
 import org.eclipse.core.runtime.IStatus;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
@@ -58,6 +59,7 @@ public class CompensationQuantifierSettings extends AbstractPeakQuantifierSettin
 		this.compensationSettings = settings.extractSettings(compensationSetting);
 	}
 
+	@JsonIgnore
 	public List<CompensationSetting> getCompensationSettings() {
 
 		CompensationQuantListUtil util = new CompensationQuantListUtil();

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/settings/PeakIntegrationSettings.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/settings/PeakIntegrationSettings.java
@@ -18,6 +18,7 @@ import org.eclipse.chemclipse.chromatogram.xxd.integrator.core.settings.peaks.Ab
 import org.eclipse.chemclipse.support.settings.StringSettingsProperty;
 import org.eclipse.core.runtime.IStatus;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
@@ -55,6 +56,7 @@ public class PeakIntegrationSettings extends AbstractPeakIntegrationSettings imp
 		this.integratorSettings = settings.extractSettings(integratorSettings);
 	}
 
+	@JsonIgnore
 	public List<IntegratorSetting> getIntegratorSettings() {
 
 		PeakIntegratorListUtil util = new PeakIntegratorListUtil();

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/settings/StandardsAssignerSettings.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/settings/StandardsAssignerSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Lablicate GmbH.
+ * Copyright (c) 2018, 2021 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,7 @@ import org.eclipse.chemclipse.chromatogram.msd.quantitation.settings.AbstractPea
 import org.eclipse.chemclipse.support.settings.StringSettingsProperty;
 import org.eclipse.core.runtime.IStatus;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
@@ -60,6 +61,7 @@ public class StandardsAssignerSettings extends AbstractPeakQuantifierSettings im
 		this.assignerSettings = settings.extractSettings(assignerSettings);
 	}
 
+	@JsonIgnore
 	public List<AssignerStandard> getAssignerSettings() {
 
 		StandardsAssignerListUtil util = new StandardsAssignerListUtil();

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/settings/StandardsReferencerSettings.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/settings/StandardsReferencerSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Lablicate GmbH.
+ * Copyright (c) 2018, 2021 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,7 @@ import org.eclipse.chemclipse.chromatogram.msd.quantitation.settings.AbstractPea
 import org.eclipse.chemclipse.support.settings.StringSettingsProperty;
 import org.eclipse.core.runtime.IStatus;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
@@ -56,6 +57,7 @@ public class StandardsReferencerSettings extends AbstractPeakQuantifierSettings 
 		this.referencerSettings = settings.extractSettings(referencerSettings);
 	}
 
+	@JsonIgnore
 	public List<AssignerReference> getReferencerSettings() {
 
 		StandardsReferencerListUtil util = new StandardsReferencerListUtil();


### PR DESCRIPTION
Closes https://github.com/OpenChrom/openchrom/issues/151. Some already had the `JsonIgnore` flag, but not all. This is a followup to https://github.com/eclipse/chemclipse/pull/737.