### PR TITLE
Added continuous integration tests to the pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+###############################################################################
+# Copyright (c) 2021 ArSysOp and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# https://www.eclipse.org/legal/epl-2.0/.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Alexander Fedorov (ArSysOp) - initial API and implementation
+#     Matthias Mailänder - adapted for OpenChrom
+###############################################################################
+
+name: Continuous Integration
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Set up JDK 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Setup Maven
+      run: echo "MAVEN_OPTS='-Xmx2048m'" > ~/.mavenrc
+    - name: Cache maven repo
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-maven-repo
+      with:
+        path: |
+          ~/.m2/repository
+          !~/.m2/repository/.cache/tycho
+          !~/.m2/repository/net/openchrom/
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.sha1') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+    - name: Build with Maven
+      run: mvn -f openchrom/releng/net.openchrom.aggregator/pom.xml clean install --no-transfer-progress -U -DskipTests

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,48 @@
+# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+#
+#  Contributors:
+#  Thomas Jaeckle - initial API and implementation
+#  Yufei Cai - fix head vs base ahead error
+#  Matthias Mailänder - check all files and account for year ranges
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+name: license-check
+
+on:
+  pull_request:
+
+jobs:
+  check-license-header-year:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jitterbit/get-changed-files@v1
+        id: changed-files
+        continue-on-error: true
+      - name: Print changed files
+        run: |
+          echo "Changed:"
+          echo "${{ steps.changed-files.outputs.all }}"
+      - name: Check year in license header
+        shell: bash
+        run: |
+          included_file_endings=".*\.(java)"
+          current_year=$(date +'%Y')
+          missing_counter=0
+          for file in ${{ steps.changed-files.outputs.all }}; do
+            if [[ $file =~ $included_file_endings ]]; then
+              if grep -q "Copyright (c) $current_year" $file; then
+                printf "\xE2\x9C\x94 $file\n"
+              elif grep -q "Copyright (c) [0-9]\{4\}, $current_year" $file; then
+                printf "\xE2\x9C\x94 $file\n"
+              else
+                printf "\xE2\x9D\x8C $file\n\tCopyright header with '$current_year' is missing from changed file.\n"
+                missing_counter=$(expr $missing_counter + 1)
+              fi
+            fi
+          done
+          exit $missing_counter


### PR DESCRIPTION
This adds https://github.com/eclipse/chemclipse/pull/772 and https://github.com/eclipse/birt/blob/master/.github/workflows/ci.yml to prevent cases where the Maven build is broken although it builds in the IDE.