### PR TITLE
Added support for .animl mass spectra

### DIFF
--- a/openchrom/plugins/net.openchrom.csd.converter.supplier.animl/src/net/openchrom/csd/converter/supplier/animl/io/ChromatogramReader.java
+++ b/openchrom/plugins/net.openchrom.csd.converter.supplier.animl/src/net/openchrom/csd/converter/supplier/animl/io/ChromatogramReader.java
@@ -70,8 +70,8 @@ public class ChromatogramReader extends AbstractChromatogramCSDReader {
 			AnIMLType animl = XmlReader.getAnIML(file);
 			chromatogram = new VendorChromatogram();
 			chromatogram = readSample(animl, chromatogram);
-			List<Float> retentionTimes = new ArrayList<Float>();
-			List<Float> signals = new ArrayList<Float>();
+			List<Float> retentionTimes = new ArrayList<>();
+			List<Float> signals = new ArrayList<>();
 			for(ExperimentStepType experimentStep : animl.getExperimentStepSet().getExperimentStep()) {
 				if(experimentStep.getTechnique().getName().equals("Flame Ionization Detector")) {
 					MethodType method = experimentStep.getMethod();

--- a/openchrom/plugins/net.openchrom.csd.converter.supplier.animl/src/net/openchrom/csd/converter/supplier/animl/io/ChromatogramWriter.java
+++ b/openchrom/plugins/net.openchrom.csd.converter.supplier.animl/src/net/openchrom/csd/converter/supplier/animl/io/ChromatogramWriter.java
@@ -31,12 +31,10 @@ import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IScan;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
 import org.eclipse.chemclipse.support.history.IEditInformation;
-import org.eclipse.core.runtime.IProduct;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.Platform;
-import org.osgi.framework.Version;
 
 import net.openchrom.xxd.converter.supplier.animl.internal.converter.BinaryReader;
+import net.openchrom.xxd.converter.supplier.animl.internal.converter.Common;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.AnIMLType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.AuditTrailEntrySetType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.AuditTrailEntryType;
@@ -51,7 +49,6 @@ import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.Sampl
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SampleType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SeriesSetType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SeriesType;
-import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SoftwareType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.TechniqueType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.UnitType;
 import net.openchrom.xxd.converter.supplier.animl.preferences.PreferenceSupplier;
@@ -171,20 +168,8 @@ public class ChromatogramWriter extends AbstractChromatogramCSDWriter {
 		author.setName(chromatogram.getOperator());
 		MethodType method = new MethodType();
 		method.setAuthor(author);
-		method.setSoftware(createSoftware());
+		method.setSoftware(Common.createSoftware());
 		return method;
-	}
-
-	private SoftwareType createSoftware() {
-
-		SoftwareType software = new SoftwareType();
-		software.setName("OpenChrom");
-		IProduct product = Platform.getProduct();
-		Version version = product.getDefiningBundle().getVersion();
-		software.setVersion(version.toString());
-		software.setManufacturer("Lablicate GmbH");
-		software.setOperatingSystem(System.getProperty("os.name"));
-		return software;
 	}
 
 	private TechniqueType createChromatographyTechnique() {
@@ -216,7 +201,7 @@ public class ChromatogramWriter extends AbstractChromatogramCSDWriter {
 		AuditTrailEntrySetType auditTrailEntrySet = new AuditTrailEntrySetType();
 		for(IEditInformation editHistory : chromatogram.getEditHistory()) {
 			AuditTrailEntryType auditTrail = new AuditTrailEntryType();
-			auditTrail.setSoftware(createSoftware());
+			auditTrail.setSoftware(Common.createSoftware());
 			AuthorType author = new AuthorType();
 			author.setName(editHistory.getEditor());
 			auditTrail.setAuthor(author);

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/plugin.xml
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/plugin.xml
@@ -4,7 +4,7 @@
    <extension
          point="org.eclipse.chemclipse.msd.converter.chromatogramSupplier">
       <ChromatogramSupplier
-            description="Reads Analytical Information Markup Language Chromatograms"
+            description="Reads and writes Analytical Information Markup Language Chromatograms"
             fileExtension=".animl"
             filterName="AnIML MSD Chromatogram (*.animl)"
             id="net.openchrom.msd.converter.supplier.animl.chromatogram"
@@ -14,5 +14,33 @@
             isExportable="true"
             isImportable="true">
       </ChromatogramSupplier>
+   </extension>
+   <extension
+         point="org.eclipse.chemclipse.msd.converter.massSpectrumSupplier">
+      <MassSpectrumSupplier
+            description="Reads and writes Analytical Information Markup Language Mass Spectra"
+            exportConverter="net.openchrom.msd.converter.supplier.animl.converter.MassSpectrumExportConverter"
+            fileExtension=".animl"
+            filterName="AnIML Mass Spectrum (*.animl)"
+            id="net.openchrom.msd.converter.supplier.animl.spectrum"
+            importConverter="net.openchrom.msd.converter.supplier.animl.converter.MassSpectrumImportConverter"
+            importMagicNumberMatcher="net.openchrom.msd.converter.supplier.animl.converter.MassSpectrumMagicNumberMatcher"
+            isExportable="true"
+            isImportable="true">
+      </MassSpectrumSupplier>
+   </extension>
+   <extension
+         point="org.eclipse.chemclipse.msd.converter.databaseSupplier">
+      <DatabaseSupplier
+            description="RReads and writes Analytical Information Markup Language Library Mass Spectra."
+            exportConverter="net.openchrom.msd.converter.supplier.animl.converter.DatabaseExportConverter"
+            fileExtension=".animl"
+            filterName="AnIML Mass Spectrum Library (*.animl)"
+            id="net.openchrom.msd.process.supplier.animl.spectrum.db"
+            importConverter="net.openchrom.msd.converter.supplier.animl.converter.DatabaseImportConverter"
+            importMagicNumberMatcher="net.openchrom.msd.converter.supplier.animl.converter.MassSpectrumMagicNumberMatcher"
+            isExportable="true"
+            isImportable="true">
+      </DatabaseSupplier>
    </extension>
 </plugin>

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/converter/ChromatogramMagicNumberMatcher.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/converter/ChromatogramMagicNumberMatcher.java
@@ -25,7 +25,7 @@ import org.w3c.dom.NodeList;
 import net.openchrom.xxd.converter.supplier.animl.internal.converter.IConstants;
 import net.openchrom.xxd.converter.supplier.animl.internal.converter.SpecificationValidator;
 
-public class MagicNumberMatcher extends AbstractMagicNumberMatcher implements IMagicNumberMatcher {
+public class ChromatogramMagicNumberMatcher extends AbstractMagicNumberMatcher implements IMagicNumberMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/converter/DatabaseExportConverter.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/converter/DatabaseExportConverter.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2021 Walter Whitlock, Philip Wenig.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Walter Whitlock - initial API and implementation
+ * Philip Wenig - initial API and implementation
+ *******************************************************************************/
+package net.openchrom.msd.converter.supplier.animl.converter;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.msd.converter.database.AbstractDatabaseExportConverter;
+import org.eclipse.chemclipse.msd.converter.io.IMassSpectraWriter;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.processing.core.ProcessingInfo;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import net.openchrom.msd.converter.supplier.animl.io.MassSpectrumWriter;
+import net.openchrom.xxd.converter.supplier.animl.internal.converter.SpecificationValidator;
+
+public class DatabaseExportConverter extends AbstractDatabaseExportConverter {
+
+	private static final Logger logger = Logger.getLogger(DatabaseExportConverter.class);
+	private static final String DESCRIPTION = "AnIML Database Mass Spectrum Export";
+
+	@Override
+	public IProcessingInfo<File> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
+
+		IProcessingInfo<File> processingInfo = validate(file, massSpectrum);
+		if(!processingInfo.hasErrorMessages()) {
+			try {
+				/*
+				 * Convert the mass spectrum.
+				 */
+				IMassSpectraWriter massSpectraWriter = new MassSpectrumWriter();
+				massSpectraWriter.write(file, massSpectrum, append, monitor);
+				processingInfo.setProcessingResult(file);
+			} catch(FileNotFoundException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, "The file couldn't be found: " + file.getAbsolutePath());
+			} catch(FileIsNotWriteableException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, "The file is not writeable: " + file.getAbsolutePath());
+			} catch(IOException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, "Something has gone completely wrong: " + file.getAbsolutePath());
+			}
+		}
+		return processingInfo;
+	}
+
+	@Override
+	public IProcessingInfo<File> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
+
+		file = SpecificationValidator.validateSpecification(file);
+		IProcessingInfo<File> processingInfo = validate(file, massSpectra);
+		if(!processingInfo.hasErrorMessages()) {
+			try {
+				/*
+				 * Convert the mass spectra.
+				 */
+				IMassSpectraWriter massSpectraWriter = new MassSpectrumWriter();
+				massSpectraWriter.write(file, massSpectra, append, monitor);
+				processingInfo.setProcessingResult(file);
+			} catch(FileNotFoundException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, "The file couldn't be found: " + file.getAbsolutePath());
+			} catch(FileIsNotWriteableException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, "The file is not writeable: " + file.getAbsolutePath());
+			} catch(IOException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, "Something has gone completely wrong: " + file.getAbsolutePath());
+			}
+		}
+		return processingInfo;
+	}
+
+	private IProcessingInfo<File> validate(File file, IScanMSD massSpectrum) {
+
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
+		processingInfo.addMessages(super.validate(file));
+		processingInfo.addMessages(super.validate(massSpectrum));
+		return processingInfo;
+	}
+
+	private IProcessingInfo<File> validate(File file, IMassSpectra massSpectra) {
+
+		IProcessingInfo<File> processingInfo = new ProcessingInfo<>();
+		processingInfo.addMessages(super.validate(file));
+		processingInfo.addMessages(super.validate(massSpectra));
+		return processingInfo;
+	}
+}

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/converter/DatabaseImportConverter.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/converter/DatabaseImportConverter.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2021 Walter Whitlock, Philip Wenig.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Walter Whitlock - initial API and implementation
+ * Philip Wenig - initial API and implementation
+ * Alexander Kerner - Generics
+ *******************************************************************************/
+package net.openchrom.msd.converter.supplier.animl.converter;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
+import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.msd.converter.database.AbstractDatabaseImportConverter;
+import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import net.openchrom.msd.converter.supplier.animl.io.MassSpectrumReader;
+import net.openchrom.xxd.converter.supplier.animl.internal.converter.SpecificationValidator;
+
+public class DatabaseImportConverter extends AbstractDatabaseImportConverter {
+
+	private static final Logger logger = Logger.getLogger(DatabaseImportConverter.class);
+	private static final String DESCRIPTION = "AnIML Database Mass Spectrum Import";
+
+	@Override
+	public IProcessingInfo<IMassSpectra> convert(File file, IProgressMonitor monitor) {
+
+		IProcessingInfo<IMassSpectra> processingInfo = super.validate(file);
+		if(!processingInfo.hasErrorMessages()) {
+			try {
+				file = SpecificationValidator.validateSpecification(file);
+				IMassSpectraReader massSpectraReader = new MassSpectrumReader();
+				IMassSpectra massSpectra = massSpectraReader.read(file, monitor);
+				if(massSpectra != null && massSpectra.size() > 0) {
+					processingInfo.setProcessingResult(massSpectra);
+				} else {
+					processingInfo.addErrorMessage(DESCRIPTION, "No mass spectra are stored." + file.getAbsolutePath());
+				}
+			} catch(FileNotFoundException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, "The file couldn't be found: " + file.getAbsolutePath());
+			} catch(FileIsNotReadableException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, "The file is not readable: " + file.getAbsolutePath());
+			} catch(FileIsEmptyException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, "The file is empty: " + file.getAbsolutePath());
+			} catch(IOException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, "Something has gone completely wrong: " + file.getAbsolutePath());
+			}
+		}
+		return processingInfo;
+	}
+}

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/converter/MassSpectrumExportConverter.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/converter/MassSpectrumExportConverter.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * 
+ * All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Dr. Philip Wenig - initial API and implementation
+ * Matthias Mailänder - adapted for MALDI
+ *******************************************************************************/
+package net.openchrom.msd.converter.supplier.animl.converter;
+
+import java.io.File;
+
+import org.eclipse.chemclipse.msd.converter.massspectrum.AbstractMassSpectrumExportConverter;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.chemclipse.processing.core.ProcessingInfo;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+public class MassSpectrumExportConverter extends AbstractMassSpectrumExportConverter {
+
+	private static final String DESCRIPTION = "AnIML Mass Spectra Export Converter";
+
+	@Override
+	public IProcessingInfo<IMassSpectra> convert(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) {
+
+		return getProcessingInfo();
+	}
+
+	@Override
+	public IProcessingInfo<IMassSpectra> convert(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) {
+
+		return getProcessingInfo();
+	}
+
+	private IProcessingInfo<IMassSpectra> getProcessingInfo() {
+
+		IProcessingInfo<IMassSpectra> processingInfo = new ProcessingInfo<>();
+		processingInfo.addErrorMessage(DESCRIPTION, "It's not possible to export mass spectrum data as mzXML yet.");
+		return processingInfo;
+	}
+}

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/converter/MassSpectrumImportConverter.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/converter/MassSpectrumImportConverter.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2021 Lablicate GmbH.
+ * 
+ * All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Dr. Philip Wenig - initial API and implementation
+ * Christoph Läubrich - add generics
+ * Matthias Mailänder - adapted for MALDI
+ *******************************************************************************/
+package net.openchrom.msd.converter.supplier.animl.converter;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
+import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
+import org.eclipse.chemclipse.msd.converter.massspectrum.AbstractMassSpectrumImportConverter;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.processing.core.IProcessingInfo;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import net.openchrom.msd.converter.supplier.animl.io.MassSpectrumReader;
+import net.openchrom.xxd.converter.supplier.animl.internal.converter.SpecificationValidator;
+
+public class MassSpectrumImportConverter extends AbstractMassSpectrumImportConverter {
+
+	private static final Logger logger = Logger.getLogger(MassSpectrumImportConverter.class);
+	private static final String DESCRIPTION = "AnIML Mass Spectrum Import";
+
+	@Override
+	public IProcessingInfo<IMassSpectra> convert(File file, IProgressMonitor monitor) {
+
+		IProcessingInfo<IMassSpectra> processingInfo = super.validate(file);
+		if(!processingInfo.hasErrorMessages()) {
+			try {
+				file = SpecificationValidator.validateSpecification(file);
+				IMassSpectraReader massSpectraReader = new MassSpectrumReader();
+				IMassSpectra massSpectra = massSpectraReader.read(file, monitor);
+				if(massSpectra != null && massSpectra.size() > 0) {
+					processingInfo.setProcessingResult(massSpectra);
+				} else {
+					processingInfo.addErrorMessage(DESCRIPTION, "No mass spectra are stored." + file.getAbsolutePath());
+				}
+			} catch(FileNotFoundException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, "The file couldn't be found: " + file.getAbsolutePath());
+			} catch(FileIsNotReadableException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, "The file is not readable: " + file.getAbsolutePath());
+			} catch(FileIsEmptyException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, "The file is empty: " + file.getAbsolutePath());
+			} catch(IOException e) {
+				logger.warn(e);
+				processingInfo.addErrorMessage(DESCRIPTION, "Something has gone completely wrong: " + file.getAbsolutePath());
+			}
+		}
+		return processingInfo;
+	}
+}

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/converter/MassSpectrumMagicNumberMatcher.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/converter/MassSpectrumMagicNumberMatcher.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2021 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package net.openchrom.msd.converter.supplier.animl.converter;
+
+import java.io.File;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.eclipse.chemclipse.converter.core.AbstractMagicNumberMatcher;
+import org.eclipse.chemclipse.converter.core.IMagicNumberMatcher;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import net.openchrom.xxd.converter.supplier.animl.internal.converter.IConstants;
+import net.openchrom.xxd.converter.supplier.animl.internal.converter.SpecificationValidator;
+
+public class MassSpectrumMagicNumberMatcher extends AbstractMagicNumberMatcher implements IMagicNumberMatcher {
+
+	@Override
+	public boolean checkFileFormat(File file) {
+
+		boolean isValidFormat = false;
+		try {
+			file = SpecificationValidator.validateSpecification(file);
+			if(!file.exists()) {
+				return isValidFormat;
+			}
+			if(!checkFileExtension(file, ".animl")) {
+				return isValidFormat;
+			}
+			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+			Document document = documentBuilder.parse(file);
+			NodeList root = document.getElementsByTagName(IConstants.NODE_ANIML);
+			if(root.getLength() != 1) {
+				return isValidFormat;
+			}
+			NodeList techniquesList = document.getElementsByTagName(IConstants.NODE_TECHNIQUE);
+			int techniques = techniquesList.getLength();
+			for(int t = 0; t < techniques; t++) {
+				Element element = (Element)techniquesList.item(t);
+				if(element.getAttribute("name").equals("Mass Spectrometry")) {
+					isValidFormat = true;
+				}
+			}
+		} catch(Exception e) {
+			// fail silently
+		}
+		return isValidFormat;
+	}
+}

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/io/ChromatogramWriter.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/io/ChromatogramWriter.java
@@ -31,12 +31,10 @@ import org.eclipse.chemclipse.msd.converter.io.AbstractChromatogramMSDWriter;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IChromatogramPeakMSD;
 import org.eclipse.chemclipse.support.history.IEditInformation;
-import org.eclipse.core.runtime.IProduct;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.Platform;
-import org.osgi.framework.Version;
 
 import net.openchrom.xxd.converter.supplier.animl.internal.converter.BinaryReader;
+import net.openchrom.xxd.converter.supplier.animl.internal.converter.Common;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.AnIMLType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.AuditTrailEntrySetType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.AuditTrailEntryType;
@@ -53,7 +51,6 @@ import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.Sampl
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SampleType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SeriesSetType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SeriesType;
-import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SoftwareType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.TechniqueType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.UnitType;
 import net.openchrom.xxd.converter.supplier.animl.preferences.PreferenceSupplier;
@@ -287,20 +284,8 @@ public class ChromatogramWriter extends AbstractChromatogramMSDWriter {
 		author.setName(chromatogram.getOperator());
 		MethodType method = new MethodType();
 		method.setAuthor(author);
-		method.setSoftware(createSoftware());
+		method.setSoftware(Common.createSoftware());
 		return method;
-	}
-
-	private SoftwareType createSoftware() {
-
-		SoftwareType software = new SoftwareType();
-		software.setName("OpenChrom");
-		IProduct product = Platform.getProduct();
-		Version version = product.getDefiningBundle().getVersion();
-		software.setVersion(version.toString());
-		software.setManufacturer("Lablicate GmbH");
-		software.setOperatingSystem(System.getProperty("os.name"));
-		return software;
 	}
 
 	private TechniqueType createChromatographyTechnique() {
@@ -332,7 +317,7 @@ public class ChromatogramWriter extends AbstractChromatogramMSDWriter {
 		AuditTrailEntrySetType auditTrailEntrySet = new AuditTrailEntrySetType();
 		for(IEditInformation editHistory : chromatogram.getEditHistory()) {
 			AuditTrailEntryType auditTrail = new AuditTrailEntryType();
-			auditTrail.setSoftware(createSoftware());
+			auditTrail.setSoftware(Common.createSoftware());
 			AuthorType author = new AuthorType();
 			author.setName(editHistory.getEditor());
 			auditTrail.setAuthor(author);

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/io/MassSpectrumReader.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/io/MassSpectrumReader.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Lablicate GmbH.
+ * 
+ * All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package net.openchrom.msd.converter.supplier.animl.io;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.List;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.eclipse.chemclipse.converter.exceptions.FileIsEmptyException;
+import org.eclipse.chemclipse.converter.exceptions.FileIsNotReadableException;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.model.exceptions.AbundanceLimitExceededException;
+import org.eclipse.chemclipse.msd.converter.io.AbstractMassSpectraReader;
+import org.eclipse.chemclipse.msd.converter.io.IMassSpectraReader;
+import org.eclipse.chemclipse.msd.model.core.AbstractIon;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IVendorMassSpectrum;
+import org.eclipse.chemclipse.msd.model.exceptions.IonLimitExceededException;
+import org.eclipse.chemclipse.msd.model.implementation.VendorMassSpectrum;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.xml.sax.SAXException;
+
+import net.openchrom.msd.converter.supplier.animl.model.IVendorIon;
+import net.openchrom.msd.converter.supplier.animl.model.IVendorMassSpectra;
+import net.openchrom.msd.converter.supplier.animl.model.VendorIon;
+import net.openchrom.msd.converter.supplier.animl.model.VendorMassSpectra;
+import net.openchrom.xxd.converter.supplier.animl.internal.converter.BinaryReader;
+import net.openchrom.xxd.converter.supplier.animl.internal.converter.XmlReader;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.AnIMLType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.CategoryType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.EncodedValueSetType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.ExperimentStepType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.IndividualValueSetType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.ParameterType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.ResultType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SampleType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SeriesSetType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SeriesType;
+
+public class MassSpectrumReader extends AbstractMassSpectraReader implements IMassSpectraReader {
+
+	private static final Logger logger = Logger.getLogger(MassSpectrumReader.class);
+
+	@Override
+	public IMassSpectra read(File file, IProgressMonitor monitor) throws FileNotFoundException, FileIsNotReadableException, FileIsEmptyException, IOException {
+
+		IVendorMassSpectrum massSpectrum = null;
+		//
+		try {
+			AnIMLType animl = XmlReader.getAnIML(file);
+			//
+			massSpectrum = new VendorMassSpectrum();
+			massSpectrum = readSample(animl, massSpectrum);
+			massSpectrum.setFile(file);
+			massSpectrum.setIdentifier(file.getName());
+			//
+			double[] mzs = null;
+			float[] intensities = null;
+			int length = 0;
+			//
+			for(ExperimentStepType experimentStep : animl.getExperimentStepSet().getExperimentStep()) {
+				if(experimentStep.getTechnique().getName().equals("Mass Spectrometry")) {
+					for(ResultType result : experimentStep.getResult()) {
+						for(CategoryType categeory : result.getCategory()) {
+							for(ParameterType parameter : categeory.getParameter()) {
+								if(parameter.getName().equals("Type")) {
+									if(parameter.getS().contains("Centroided"))
+										massSpectrum.setMassSpectrumType((short)0);
+									else if(parameter.getS().contains("Continuous"))
+										massSpectrum.setMassSpectrumType((short)1);
+								}
+							}
+						}
+						SeriesSetType seriesSet = result.getSeriesSet();
+						length = seriesSet.getLength();
+						mzs = new double[length];
+						intensities = new float[length];
+						if(seriesSet.getName().equals("Spectrum")) {
+							for(SeriesType series : seriesSet.getSeries()) {
+								if(series.getName().equals("Mass/Charge")) {
+									for(IndividualValueSetType individualValueSet : series.getIndividualValueSet()) {
+										List<Double> doubles = individualValueSet.getD();
+										for(int i = 0; i < doubles.size(); i++) {
+											mzs[i] = doubles.get(i);
+										}
+									}
+									for(EncodedValueSetType encodedValueSet : series.getEncodedValueSet()) {
+										mzs = BinaryReader.decodeDoubleArray(encodedValueSet.getValue());
+									}
+								}
+								if(series.getName().equals("Intensity")) {
+									for(IndividualValueSetType individualValueSet : series.getIndividualValueSet()) {
+										List<Float> floats = individualValueSet.getF();
+										for(int i = 0; i < floats.size(); i++) {
+											intensities[i] = floats.get(i);
+										}
+									}
+									for(EncodedValueSetType encodedValueSet : series.getEncodedValueSet()) {
+										intensities = BinaryReader.decodeFloatArray(encodedValueSet.getValue());
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			for(int i = 0; i < length; i++) {
+				try {
+					double intensity = intensities[i];
+					if(intensity >= VendorIon.MIN_ABUNDANCE && intensity <= VendorIon.MAX_ABUNDANCE) {
+						double mz = AbstractIon.getIon(mzs[i]);
+						IVendorIon ion = new VendorIon(mz, (float)intensity);
+						massSpectrum.addIon(ion);
+					}
+				} catch(AbundanceLimitExceededException e) {
+					logger.warn(e);
+				} catch(IonLimitExceededException e) {
+					logger.warn(e);
+				}
+			}
+		} catch(SAXException e) {
+			logger.warn(e);
+		} catch(JAXBException e) {
+			logger.warn(e);
+		} catch(ParserConfigurationException e) {
+			logger.warn(e);
+		}
+		//
+		IVendorMassSpectra massSpectra = new VendorMassSpectra();
+		massSpectra.setName(file.getName());
+		massSpectra.addMassSpectrum(massSpectrum);
+		return massSpectra;
+	}
+
+	private IVendorMassSpectrum readSample(AnIMLType animl, IVendorMassSpectrum massSpectrum) {
+
+		SampleType sample = animl.getSampleSet().getSample().get(0);
+		massSpectrum.setIdentifier(sample.getSampleID());
+		return massSpectrum;
+	}
+}

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/io/MassSpectrumWriter.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/io/MassSpectrumWriter.java
@@ -1,0 +1,211 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Lablicate GmbH.
+ * 
+ * All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package net.openchrom.msd.converter.supplier.animl.io;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+
+import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
+import org.eclipse.chemclipse.logging.core.Logger;
+import org.eclipse.chemclipse.msd.converter.io.IMassSpectraWriter;
+import org.eclipse.chemclipse.msd.model.core.IIon;
+import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
+import org.eclipse.chemclipse.msd.model.core.IScanMSD;
+import org.eclipse.chemclipse.msd.model.core.IVendorMassSpectrum;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import net.openchrom.xxd.converter.supplier.animl.internal.converter.BinaryReader;
+import net.openchrom.xxd.converter.supplier.animl.internal.converter.Common;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.AnIMLType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.AuditTrailEntrySetType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.AuditTrailEntryType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.CategoryType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.EncodedValueSetType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.ExperimentStepSetType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.ExperimentStepType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.IndividualValueSetType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.MethodType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.ParameterType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.ResultType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SampleSetType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SampleType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SeriesSetType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SeriesType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.TechniqueType;
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.UnitType;
+import net.openchrom.xxd.converter.supplier.animl.preferences.PreferenceSupplier;
+
+public class MassSpectrumWriter implements IMassSpectraWriter {
+
+	private static final Logger logger = Logger.getLogger(MassSpectrumWriter.class);
+
+	@Override
+	public void write(File file, IScanMSD massSpectrum, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
+
+		FileWriter fileWriter = new FileWriter(file, append);
+		writeMassSpectrum(fileWriter, massSpectrum, monitor);
+		fileWriter.close();
+	}
+
+	@Override
+	public void write(File file, IMassSpectra massSpectra, boolean append, IProgressMonitor monitor) throws FileIsNotWriteableException, IOException {
+
+		FileWriter fileWriter = new FileWriter(file, append);
+		writeMassSpectra(fileWriter, massSpectra, monitor);
+		fileWriter.close();
+	}
+
+	private void writeMassSpectra(FileWriter fileWriter, IMassSpectra massSpectra, IProgressMonitor monitor) throws IOException {
+
+		for(int i = 1; i <= massSpectra.size(); i++) {
+			IScanMSD massSpectrum = massSpectra.getMassSpectrum(i);
+			if(massSpectrum != null && massSpectrum.getNumberOfIons() > 0) {
+				writeMassSpectrum(fileWriter, massSpectrum, monitor);
+			}
+		}
+	}
+
+	@Override
+	public void writeMassSpectrum(FileWriter fileWriter, IScanMSD massSpectrum, IProgressMonitor monitor) throws IOException {
+
+		try {
+			writeAnIML(fileWriter, (IVendorMassSpectrum)massSpectrum);
+		} catch(JAXBException e) {
+			logger.warn(e);
+		}
+	}
+
+	private void writeAnIML(FileWriter fileWriter, IVendorMassSpectrum massSpectrum) throws JAXBException {
+
+		JAXBContext jaxbContext = JAXBContext.newInstance(AnIMLType.class);
+		Marshaller marshaller = jaxbContext.createMarshaller();
+		//
+		AnIMLType anIML = new AnIMLType();
+		anIML.setSampleSet(createSampleSet(massSpectrum));
+		anIML.setExperimentStepSet(createExperimentStep(massSpectrum));
+		anIML.setAuditTrailEntrySet(createAuditTrail());
+		marshaller.marshal(anIML, fileWriter);
+	}
+
+	private SampleSetType createSampleSet(IVendorMassSpectrum massSpectrum) {
+
+		SampleSetType sampleSet = new SampleSetType();
+		SampleType sample = new SampleType();
+		sample.setName(massSpectrum.getName());
+		sample.setSampleID(massSpectrum.getIdentifier());
+		sample.setSourceDataLocation(massSpectrum.getFile().getAbsolutePath());
+		sampleSet.getSample().add(sample);
+		return sampleSet;
+	}
+
+	private ExperimentStepSetType createExperimentStep(IVendorMassSpectrum massSpectrum) {
+
+		ExperimentStepSetType experimentStepSet = new ExperimentStepSetType();
+		ExperimentStepType massSpecStep = new ExperimentStepType();
+		massSpecStep.setTechnique(createMassSpecTechnique());
+		massSpecStep.getResult().add(createResult(massSpectrum));
+		massSpecStep.setMethod(createMethod());
+		experimentStepSet.getExperimentStep().add(massSpecStep);
+		return experimentStepSet;
+	}
+
+	private TechniqueType createMassSpecTechnique() {
+
+		TechniqueType technique = new TechniqueType();
+		technique.setName("Mass Spectrometry");
+		technique.setUri("https://github.com/AnIML/techniques/blob/db3fcd831c4fce00b647b7e6d8c21f753b76f361/mass-spec.atdd");
+		return technique;
+	}
+
+	private ResultType createResult(IVendorMassSpectrum massSpectrum) {
+
+		SeriesSetType seriesSet = new SeriesSetType();
+		seriesSet.setName("Spectrum");
+		seriesSet.setLength(massSpectrum.getNumberOfIons());
+		//
+		SeriesType massChargeSeries = new SeriesType();
+		massChargeSeries.setName("Mass/Charge");
+		UnitType massChargeUnit = new UnitType();
+		massChargeUnit.setLabel("Mass/Charge Ratio");
+		massChargeUnit.setQuantity("mz");
+		massChargeSeries.setUnit(massChargeUnit);
+		//
+		SeriesType intensitySeries = new SeriesType();
+		intensitySeries.setName("Intensity");
+		UnitType intensityUnit = new UnitType();
+		intensityUnit.setLabel("Abundance");
+		intensityUnit.setQuantity("arbitrary");
+		intensitySeries.setUnit(intensityUnit);
+		//
+		if(PreferenceSupplier.getMassSpectrumSaveEncoded()) {
+			int scans = massSpectrum.getNumberOfIons();
+			double[] ions = new double[scans];
+			float[] intensities = new float[scans];
+			int i = 0;
+			for(IIon ion : massSpectrum.getIons()) {
+				ions[i] = ion.getIon();
+				intensities[i] = ion.getAbundance();
+				i++;
+			}
+			EncodedValueSetType encodedIons = new EncodedValueSetType();
+			encodedIons.setValue(BinaryReader.encodeArray(ions));
+			massChargeSeries.getEncodedValueSet().add(encodedIons);
+			//
+			EncodedValueSetType encodedIntensities = new EncodedValueSetType();
+			encodedIntensities.setValue(BinaryReader.encodeArray(intensities));
+			intensitySeries.getEncodedValueSet().add(encodedIntensities);
+		} else {
+			IndividualValueSetType ions = new IndividualValueSetType();
+			IndividualValueSetType intensities = new IndividualValueSetType();
+			for(IIon ion : massSpectrum.getIons()) {
+				ions.getD().add(ion.getIon());
+				intensities.getF().add(ion.getAbundance());
+			}
+			massChargeSeries.getIndividualValueSet().add(ions);
+			intensitySeries.getIndividualValueSet().add(intensities);
+		}
+		seriesSet.getSeries().add(massChargeSeries);
+		seriesSet.getSeries().add(intensitySeries);
+		ResultType result = new ResultType();
+		CategoryType category = new CategoryType();
+		ParameterType parameter = new ParameterType();
+		parameter.setName("Type");
+		if(massSpectrum.getMassSpectrumType() == 0) {
+			parameter.getS().add("Centroided");
+		} else
+			parameter.getS().add("Continuous");
+		category.getParameter().add(parameter);
+		result.getCategory().add(category);
+		result.setSeriesSet(seriesSet);
+		return result;
+	}
+
+	private MethodType createMethod() {
+
+		MethodType method = new MethodType();
+		method.setSoftware(Common.createSoftware());
+		return method;
+	}
+
+	private AuditTrailEntrySetType createAuditTrail() {
+
+		AuditTrailEntrySetType auditTrailEntrySet = new AuditTrailEntrySetType();
+		AuditTrailEntryType auditTrail = new AuditTrailEntryType();
+		auditTrail.setSoftware(Common.createSoftware());
+		return auditTrailEntrySet;
+	}
+}

--- a/openchrom/plugins/net.openchrom.wsd.converter.supplier.animl/src/net/openchrom/wsd/converter/supplier/animl/io/ChromatogramWriter.java
+++ b/openchrom/plugins/net.openchrom.wsd.converter.supplier.animl/src/net/openchrom/wsd/converter/supplier/animl/io/ChromatogramWriter.java
@@ -33,14 +33,12 @@ import org.eclipse.chemclipse.wsd.model.core.IChromatogramPeakWSD;
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 import org.eclipse.chemclipse.wsd.model.core.IScanSignalWSD;
 import org.eclipse.chemclipse.wsd.model.core.IScanWSD;
-import org.eclipse.core.runtime.IProduct;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.Platform;
-import org.osgi.framework.Version;
 
 import com.google.common.primitives.Doubles;
 
 import net.openchrom.xxd.converter.supplier.animl.internal.converter.BinaryReader;
+import net.openchrom.xxd.converter.supplier.animl.internal.converter.Common;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.AnIMLType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.AuditTrailEntrySetType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.AuditTrailEntryType;
@@ -57,7 +55,6 @@ import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.Sampl
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SampleType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SeriesSetType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SeriesType;
-import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SoftwareType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.TechniqueType;
 import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.UnitType;
 import net.openchrom.xxd.converter.supplier.animl.preferences.PreferenceSupplier;
@@ -301,20 +298,8 @@ public class ChromatogramWriter extends AbstractChromatogramWSDWriter {
 		author.setName(chromatogram.getOperator());
 		MethodType method = new MethodType();
 		method.setAuthor(author);
-		method.setSoftware(createSoftware());
+		method.setSoftware(Common.createSoftware());
 		return method;
-	}
-
-	private SoftwareType createSoftware() {
-
-		SoftwareType software = new SoftwareType();
-		software.setName("OpenChrom");
-		IProduct product = Platform.getProduct();
-		Version version = product.getDefiningBundle().getVersion();
-		software.setVersion(version.toString());
-		software.setManufacturer("Lablicate GmbH");
-		software.setOperatingSystem(System.getProperty("os.name"));
-		return software;
 	}
 
 	private TechniqueType createChromatographyTechnique() {
@@ -346,7 +331,7 @@ public class ChromatogramWriter extends AbstractChromatogramWSDWriter {
 		AuditTrailEntrySetType auditTrailEntrySet = new AuditTrailEntrySetType();
 		for(IEditInformation editHistory : chromatogram.getEditHistory()) {
 			AuditTrailEntryType auditTrail = new AuditTrailEntryType();
-			auditTrail.setSoftware(createSoftware());
+			auditTrail.setSoftware(Common.createSoftware());
 			AuthorType author = new AuthorType();
 			author.setName(editHistory.getEditor());
 			auditTrail.setAuthor(author);

--- a/openchrom/plugins/net.openchrom.xxd.converter.supplier.animl/src/net/openchrom/xxd/converter/supplier/animl/internal/converter/BinaryReader.java
+++ b/openchrom/plugins/net.openchrom.xxd.converter.supplier.animl/src/net/openchrom/xxd/converter/supplier/animl/internal/converter/BinaryReader.java
@@ -13,6 +13,7 @@ package net.openchrom.xxd.converter.supplier.animl.internal.converter;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 
@@ -25,7 +26,7 @@ public class BinaryReader {
 		IntBuffer intBuffer = byteBuffer.asIntBuffer();
 		int[] values = new int[intBuffer.capacity()];
 		for(int index = 0; index < intBuffer.capacity(); index++) {
-			values[index] = new Integer(intBuffer.get(index));
+			values[index] = intBuffer.get(index);
 		}
 		return values;
 	}
@@ -37,7 +38,19 @@ public class BinaryReader {
 		FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
 		float[] values = new float[floatBuffer.capacity()];
 		for(int index = 0; index < floatBuffer.capacity(); index++) {
-			values[index] = new Float(floatBuffer.get(index));
+			values[index] = floatBuffer.get(index);
+		}
+		return values;
+	}
+
+	public static double[] decodeDoubleArray(byte[] binary) {
+
+		ByteBuffer byteBuffer = ByteBuffer.wrap(binary);
+		byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+		DoubleBuffer doubleBuffer = byteBuffer.asDoubleBuffer();
+		double[] values = new double[doubleBuffer.capacity()];
+		for(int index = 0; index < doubleBuffer.capacity(); index++) {
+			values[index] = doubleBuffer.get(index);
 		}
 		return values;
 	}
@@ -48,6 +61,15 @@ public class BinaryReader {
 		ByteBuffer byteBuffer = ByteBuffer.allocate(floatBuffer.capacity() * Float.BYTES);
 		byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
 		byteBuffer.asFloatBuffer().put(floatBuffer);
+		return byteBuffer.array();
+	}
+
+	public static byte[] encodeArray(double[] array) {
+
+		DoubleBuffer doubleBuffer = DoubleBuffer.wrap(array);
+		ByteBuffer byteBuffer = ByteBuffer.allocate(doubleBuffer.capacity() * Double.BYTES);
+		byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+		byteBuffer.asDoubleBuffer().put(doubleBuffer);
 		return byteBuffer.array();
 	}
 

--- a/openchrom/plugins/net.openchrom.xxd.converter.supplier.animl/src/net/openchrom/xxd/converter/supplier/animl/internal/converter/Common.java
+++ b/openchrom/plugins/net.openchrom.xxd.converter.supplier.animl/src/net/openchrom/xxd/converter/supplier/animl/internal/converter/Common.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Lablicate GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package net.openchrom.xxd.converter.supplier.animl.internal.converter;
+
+import org.eclipse.core.runtime.IProduct;
+import org.eclipse.core.runtime.Platform;
+import org.osgi.framework.Version;
+
+import net.openchrom.xxd.converter.supplier.animl.internal.model.astm.core.SoftwareType;
+
+public class Common {
+
+	public static SoftwareType createSoftware() {
+
+		SoftwareType software = new SoftwareType();
+		software.setName("OpenChrom");
+		IProduct product = Platform.getProduct();
+		Version version = product.getDefiningBundle().getVersion();
+		software.setVersion(version.toString());
+		software.setManufacturer("Lablicate GmbH");
+		software.setOperatingSystem(System.getProperty("os.name"));
+		return software;
+	}
+}

--- a/openchrom/plugins/net.openchrom.xxd.converter.supplier.animl/src/net/openchrom/xxd/converter/supplier/animl/preferences/PreferenceSupplier.java
+++ b/openchrom/plugins/net.openchrom.xxd.converter.supplier.animl/src/net/openchrom/xxd/converter/supplier/animl/preferences/PreferenceSupplier.java
@@ -28,6 +28,8 @@ public class PreferenceSupplier implements IPreferenceSupplier {
 	public static final String DEF_CHROMATOGRAM_VERSION_SAVE = IFormat.VERSION_LATEST;
 	public static final String P_CHROMATOGRAM_SAVE_ENCODED = "chromatogramEncoded";
 	public static final boolean DEF_CHROMATOGRAM_SAVE_ENCODED = true;
+	public static final String P_MASS_SPECTRUM_SAVE_ENCODED = "massSpectrumEncoded";
+	public static final boolean DEF_MASS_SPECTRUM_SAVE_ENCODED = true;
 	private static IPreferenceSupplier preferenceSupplier;
 
 	public static IPreferenceSupplier INSTANCE() {
@@ -53,9 +55,10 @@ public class PreferenceSupplier implements IPreferenceSupplier {
 	@Override
 	public Map<String, String> getDefaultValues() {
 
-		Map<String, String> defaultValues = new HashMap<String, String>();
+		Map<String, String> defaultValues = new HashMap<>();
 		defaultValues.put(P_CHROMATOGRAM_VERSION_SAVE, DEF_CHROMATOGRAM_VERSION_SAVE);
 		defaultValues.put(P_CHROMATOGRAM_SAVE_ENCODED, Boolean.toString(DEF_CHROMATOGRAM_SAVE_ENCODED));
+		defaultValues.put(P_MASS_SPECTRUM_SAVE_ENCODED, Boolean.toString(DEF_MASS_SPECTRUM_SAVE_ENCODED));
 		return defaultValues;
 	}
 
@@ -83,5 +86,11 @@ public class PreferenceSupplier implements IPreferenceSupplier {
 
 		IEclipsePreferences preferences = INSTANCE().getPreferences();
 		return preferences.getBoolean(P_CHROMATOGRAM_SAVE_ENCODED, DEF_CHROMATOGRAM_SAVE_ENCODED);
+	}
+
+	public static boolean getMassSpectrumSaveEncoded() {
+
+		IEclipsePreferences preferences = INSTANCE().getPreferences();
+		return preferences.getBoolean(P_MASS_SPECTRUM_SAVE_ENCODED, DEF_MASS_SPECTRUM_SAVE_ENCODED);
 	}
 }


### PR DESCRIPTION
For some reason, the `org.eclipse.chemclipse.msd.converter.massSpectrumSupplier` is not exposed to save as.