### PR TITLE
Fixed AnIML converter reading unrelated files and crashing

### DIFF
--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/converter/ChromatogramMagicNumberMatcher.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/converter/ChromatogramMagicNumberMatcher.java
@@ -30,10 +30,10 @@ public class ChromatogramMagicNumberMatcher extends AbstractMagicNumberMatcher i
 	public boolean checkFileFormat(File file) {
 
 		boolean isValidFormat = false;
+		if(file.isDirectory() || !checkFileExtension(file, ".animl")) {
+			return isValidFormat;
+		}
 		try {
-			if(!checkFileExtension(file, ".animl")) {
-				return isValidFormat;
-			}
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/converter/MassSpectrumMagicNumberMatcher.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/converter/MassSpectrumMagicNumberMatcher.java
@@ -30,10 +30,10 @@ public class MassSpectrumMagicNumberMatcher extends AbstractMagicNumberMatcher i
 	public boolean checkFileFormat(File file) {
 
 		boolean isValidFormat = false;
+		if(file.isDirectory() || !checkFileExtension(file, ".animl")) {
+			return isValidFormat;
+		}
 		try {
-			if(!checkFileExtension(file, ".animl")) {
-				return isValidFormat;
-			}
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(file);

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/io/ChromatogramReader.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/io/ChromatogramReader.java
@@ -72,6 +72,9 @@ public class ChromatogramReader extends AbstractChromatogramMSDReader {
 	@Override
 	public IChromatogramMSD read(File file, IProgressMonitor monitor) throws IOException {
 
+		if(file.isDirectory() || !file.getName().endsWith(".animl")) {
+			return null;
+		}
 		IVendorChromatogram chromatogram = null;
 		try {
 			AnIMLType animl = XmlReader.getAnIML(file);

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/io/MassSpectrumReader.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/io/MassSpectrumReader.java
@@ -54,6 +54,9 @@ public class MassSpectrumReader extends AbstractMassSpectraReader implements IMa
 	@Override
 	public IMassSpectra read(File file, IProgressMonitor monitor) throws IOException {
 
+		if(file.isDirectory() || !file.getName().endsWith(".animl")) {
+			return null;
+		}
 		IVendorStandaloneMassSpectrum massSpectrum = null;
 		//
 		try {


### PR DESCRIPTION
I noticed SAX exceptions for files which weren't supposed to be loaded with the AnIML converter.