### PR TITLE
Updated BioJava to 6.0.5

### DIFF
--- a/openchrom/features/net.openchrom.platform.feature/feature.xml
+++ b/openchrom/features/net.openchrom.platform.feature/feature.xml
@@ -66,10 +66,6 @@
          version="0.0.0"/>
 
    <includes
-         id="net.openchrom.thirdpartylibraries.biojava.feature"
-         version="0.0.0"/>
-
-   <includes
          id="net.openchrom.xxd.processor.supplier.tracecompare.feature"
          version="0.0.0"/>
 
@@ -181,6 +177,20 @@
 
    <plugin
          id="wrapped.us.hebi.matlab.mat.mfl-core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="wrapped.org.biojava.biojava-core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="wrapped.org.biojava.biojava-ws"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/openchrom/plugins/net.openchrom.wsd.identifier.supplier.geneident.ui/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.wsd.identifier.supplier.geneident.ui/META-INF/MANIFEST.MF
@@ -16,8 +16,9 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.chemclipse.logging;bundle-version="0.8.0",
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
- net.openchrom.thirdpartylibraries.biojava;bundle-version="4.2.4",
- org.eclipse.chemclipse.ux.extension.wsd.ui;bundle-version="0.8.0"
+ org.eclipse.chemclipse.ux.extension.wsd.ui;bundle-version="0.8.0",
+ wrapped.org.biojava.biojava-core;bundle-version="6.0.5",
+ wrapped.org.biojava.biojava-ws;bundle-version="6.0.5"
 Bundle-ManifestVersion: 2
 Bundle-Activator: net.openchrom.wsd.identifier.supplier.geneident.ui.Activator
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
+++ b/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
@@ -17,7 +17,6 @@
 <unit id="net.openchrom.thirdpartylibraries.groovy.feature.feature.group" version="0.0.0"/>
 <unit id="net.openchrom.thirdpartylibraries.lzf.feature.feature.group" version="0.0.0"/>
 <unit id="net.openchrom.thirdpartylibraries.opsin.feature.feature.group" version="0.0.0"/>
-<unit id="net.openchrom.thirdpartylibraries.biojava.feature.feature.group" version="0.0.0"/>
 <unit id="net.openchrom.thirdpartylibraries.javassist.feature.feature.group" version="0.0.0"/>
 <unit id="net.openchrom.thirdpartylibraries.xzing.feature.feature.group" version="0.0.0"/>
 <unit id="net.openchrom.thirdpartylibraries.concurrentlinkedhashmap.feature.feature.group" version="0.0.0"/>
@@ -52,6 +51,26 @@
 				<groupId>us.hebi.matlab.mat</groupId>
 				<artifactId>mfl-core</artifactId>
 				<version>0.5.8</version>
+				<type>jar</type>
+			</dependency>
+		</dependencies>
+	</location>
+	<location includeSource="true" missingManifest="generate" type="Maven">
+		<dependencies>
+			<dependency>
+				<groupId>org.biojava</groupId>
+				<artifactId>biojava-core</artifactId>
+				<version>6.0.5</version>
+				<type>jar</type>
+			</dependency>
+		</dependencies>
+	</location>
+	<location includeSource="true" missingManifest="generate" type="Maven">
+		<dependencies>
+			<dependency>
+				<groupId>org.biojava</groupId>
+				<artifactId>biojava-ws</artifactId>
+				<version>6.0.5</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
Replace BioJava with Maven wrapper so we don't need https://github.com/OpenChrom/openchrom3rdpl/pull/36 anymore.