### PR TITLE
Updated target platform to fetch JHDF5 directly from SciJava

### DIFF
--- a/openchrom/features/net.openchrom.platform.feature/feature.xml
+++ b/openchrom/features/net.openchrom.platform.feature/feature.xml
@@ -118,10 +118,6 @@
          version="0.0.0"/>
 
    <includes
-         id="net.openchrom.thirdpartylibraries.jhdf5.feature"
-         version="0.0.0"/>
-
-   <includes
          id="net.openchrom.xxd.converter.supplier.gaml.feature"
          version="0.0.0"/>
 
@@ -194,6 +190,13 @@
 
    <plugin
          id="org.xerial.sqlite-jdbc"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="wrapped.cisd.jhdf5"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.mz5/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.mz5/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
- net.openchrom.thirdpartylibraries.jhdf5;bundle-version="14.12.6"
+ wrapped.cisd.jhdf5;bundle-version="14.12.6"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: net.openchrom.msd.converter.supplier.mz5,

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.mzmlb/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.mzmlb/META-INF/MANIFEST.MF
@@ -14,8 +14,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.converter;bundle-version="0.8.0",
  org.eclipse.chemclipse.model;bundle-version="0.8.0",
  org.eclipse.chemclipse.support;bundle-version="0.8.0",
- net.openchrom.thirdpartylibraries.jhdf5,
- org.eclipse.chemclipse.msd.converter.supplier.mzml
+ org.eclipse.chemclipse.msd.converter.supplier.mzml,
+ wrapped.cisd.jhdf5;bundle-version="14.12.6"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: net.openchrom.msd.converter.supplier.mzmlb,

--- a/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
+++ b/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
@@ -24,7 +24,6 @@
 <unit id="net.openchrom.thirdpartylibraries.odfdom.feature.feature.group" version="0.0.0"/>
 <unit id="net.openchrom.thirdpartylibraries.imagej.feature.feature.group" version="0.0.0"/>
 <unit id="net.openchrom.thirdpartylibraries.jdbc.feature.feature.group" version="0.0.0"/>
-<unit id="net.openchrom.thirdpartylibraries.jhdf5.feature.feature.group" version="0.0.0"/>
 <unit id="net.openchrom.thirdpartylibraries.vectorgraphics2d.feature.feature.group" version="0.0.0"/>
 <unit id="net.openchrom.thirdpartylibraries.jna.feature.feature.group" version="0.0.0"/>
 <unit id="net.openchrom.thirdpartylibraries.pdfjet.feature.feature.group" version="0.0.0"/>
@@ -83,6 +82,22 @@
 				<type>jar</type>
 			</dependency>
 		</dependencies>
+	</location>
+	<location includeSource="true" missingManifest="generate" type="Maven">
+		<dependencies>
+			<dependency>
+				<groupId>cisd</groupId>
+				<artifactId>jhdf5</artifactId>
+				<version>14.12.6</version>
+				<type>jar</type>
+			</dependency>
+		</dependencies>
+		<repositories>
+			<repository>
+				<id>SciJava</id>
+				<url>https://maven.scijava.org/content/repositories/public/</url>
+			</repository>
+		</repositories>
 	</location>
 </locations>
 </target>


### PR DESCRIPTION
as @eclipse-m2e also allows specifying thirdparty repositories which is handy.