### PR TITLE
Increased Java heap space

### DIFF
--- a/openchrom/products/net.openchrom.rcp.compilation.community.product/openchrom.compilation.community.product
+++ b/openchrom/products/net.openchrom.rcp.compilation.community.product/openchrom.compilation.community.product
@@ -16,8 +16,8 @@
    <launcherArgs>
       <programArgs>-clearPersistedState
       </programArgs>
-      <vmArgs>-Xms512M
--Xmx1024M
+      <vmArgs>-Xms1024M
+-Xmx4096M
 -Dapplication.name=OpenChrom_Analytics_Edition
 -Dapplication.version=1.5.x
 -Denable.cli.support=false


### PR DESCRIPTION
Try reading the large files from https://zenodo.org/record/4306664 cause running out of heap spaces when reading the double arrays. I think 512 MB is really too small nowadays.