### PR TITLE
Fixed CSV Peak Report exporting the master chromatogram twice when reporting references

### DIFF
--- a/openchrom/plugins/net.openchrom.chromatogram.xxd.report.supplier.csv/src/net/openchrom/chromatogram/xxd/report/supplier/csv/io/ConfigurableReportWriter.java
+++ b/openchrom/plugins/net.openchrom.chromatogram.xxd.report.supplier.csv/src/net/openchrom/chromatogram/xxd/report/supplier/csv/io/ConfigurableReportWriter.java
@@ -54,11 +54,12 @@ public class ConfigurableReportWriter {
 			 * Data
 			 */
 			for(IChromatogram<? extends IPeak> chromatogram : chromatograms) {
-				printChromatogramData(csvPrinter, reportColumns, chromatogram, printSectionSeparator);
 				if(reportSettings.reportReferencedChromatograms()) {
 					for(IChromatogram<?> referencedChromatograms : chromatogram.getReferencedChromatograms()) {
 						printChromatogramData(csvPrinter, reportColumns, referencedChromatograms, printSectionSeparator);
 					}
+				} else {
+					printChromatogramData(csvPrinter, reportColumns, chromatogram, printSectionSeparator);
 				}
 			}
 		}


### PR DESCRIPTION
as for some reason referenced chromatograms contains the master chromatogram which is unintuitive API.