### PR TITLE
Update Maven to 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,9 @@ jobs:
         distribution: 'temurin'
         java-version: '17'
         cache: 'maven'
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.5
+      with:
+        maven-version: 3.9.4
     - name: Build with Maven
       run: cd openchrom && mvn -f openchrom/releng/net.openchrom.aggregator/pom.xml -T 1C verify --batch-mode --no-transfer-progress


### PR DESCRIPTION
https://github.com/eclipse/chemclipse/pull/1448 as [ubuntu-latest](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md) only comes with Maven 3.8.8
