### PR TITLE
Prefer a Docker solution to unverified Actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021, 2022 ArSysOp and others
+# Copyright (c) 2021, 2024 Lablicate GmbH and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -8,8 +8,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
-#     Alexander Fedorov (ArSysOp) - initial API and implementation
-#     Matthias Mailänder - adapted for OpenChrom
+#     Alexander Fedorov - initial API and implementation
+#     Matthias Mailänder - initial API and implementation
 ###############################################################################
 name: Continuous Integration
 on:
@@ -21,21 +21,13 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: maven:3.9.4-eclipse-temurin-17
 
     steps:
     - name: Checkout OpenChrom
       uses: actions/checkout@v3
       with:
         path: openchrom
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: '17'
-        cache: 'maven'
-    - name: Set up Maven
-      uses: stCarolas/setup-maven@v4.5
-      with:
-        maven-version: 3.9.4
     - name: Build with Maven
       run: cd openchrom && mvn -f openchrom/releng/net.openchrom.aggregator/pom.xml -T 1C verify --batch-mode --no-transfer-progress


### PR DESCRIPTION
With Maven not being officially supported by @GitHub [this discussion](https://github.com/actions/runner-images/discussions/8034#discussioncomment-6629063) suggests using [the official Maven docker image](https://hub.docker.com/_/maven) instead of unverified GitHub Actions provided by individuals.