### PR TITLE
Use our own ATDD mirror server

### DIFF
--- a/openchrom/plugins/net.openchrom.csd.converter.supplier.animl/src/net/openchrom/csd/converter/supplier/animl/io/ChromatogramWriter.java
+++ b/openchrom/plugins/net.openchrom.csd.converter.supplier.animl/src/net/openchrom/csd/converter/supplier/animl/io/ChromatogramWriter.java
@@ -199,7 +199,7 @@ public class ChromatogramWriter extends AbstractChromatogramCSDWriter {
 		TechniqueType technique = new TechniqueType();
 		technique.setId("CHROMATOGRAPHY");
 		technique.setName("Chromatography");
-		technique.setUri("https://github.com/AnIML/techniques/blob/6e30b1e593e6df661a44ae2a9892b6198def0641/chromatography.atdd");
+		technique.setUri("https://animl.openchrom.net/chromatography.atdd");
 		return technique;
 	}
 
@@ -208,7 +208,7 @@ public class ChromatogramWriter extends AbstractChromatogramCSDWriter {
 		TechniqueType technique = new TechniqueType();
 		technique.setId("FID");
 		technique.setName("Flame Ionization Detector");
-		technique.setUri("https://github.com/AnIML/techniques/blob/6e30b1e593e6df661a44ae2a9892b6198def0641/fid-trace.atdd");
+		technique.setUri("https://animl.openchrom.net/fid-trace.atdd");
 		return technique;
 	}
 
@@ -217,7 +217,7 @@ public class ChromatogramWriter extends AbstractChromatogramCSDWriter {
 		TechniqueType technique = new TechniqueType();
 		technique.setId("CHROMATOGRAPHY_PEAK_TABLE");
 		technique.setName("Chromatography Peak Table");
-		technique.setUri("https://github.com/AnIML/techniques/blob/d749979fc21322b97c61e2efd6efe60cfa5a29be/chromatography-peak-table.atdd");
+		technique.setUri("https://animl.openchrom.net/chromatography-peak-table.atdd");
 		return technique;
 	}
 

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/io/ChromatogramWriter.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/io/ChromatogramWriter.java
@@ -286,7 +286,7 @@ public class ChromatogramWriter extends AbstractChromatogramMSDWriter {
 		TechniqueType technique = new TechniqueType();
 		technique.setId("CHROMATOGRAPHY");
 		technique.setName("Chromatography");
-		technique.setUri("https://github.com/AnIML/techniques/blob/6e30b1e593e6df661a44ae2a9892b6198def0641/chromatography.atdd");
+		technique.setUri("https://animl.openchrom.net/chromatography.atdd");
 		return technique;
 	}
 
@@ -295,7 +295,7 @@ public class ChromatogramWriter extends AbstractChromatogramMSDWriter {
 		TechniqueType technique = new TechniqueType();
 		technique.setId("MS_TRACE");
 		technique.setName("Mass Spectrum Time Trace");
-		technique.setUri("https://github.com/AnIML/techniques/blob/2c9e7fbf5f6435b4dee9f112bdd0d81d135085ff/ms-trace.atdd");
+		technique.setUri("https://animl.openchrom.net/ms-trace.atdd");
 		return technique;
 	}
 
@@ -304,7 +304,7 @@ public class ChromatogramWriter extends AbstractChromatogramMSDWriter {
 		TechniqueType technique = new TechniqueType();
 		technique.setId("MASS_SPEC");
 		technique.setName("Mass Spectrometry");
-		technique.setUri("https://github.com/AnIML/techniques/blob/db3fcd831c4fce00b647b7e6d8c21f753b76f361/mass-spec.atdd");
+		technique.setUri("https://animl.openchrom.net/mass-spec.atdd");
 		return technique;
 	}
 
@@ -313,7 +313,7 @@ public class ChromatogramWriter extends AbstractChromatogramMSDWriter {
 		TechniqueType technique = new TechniqueType();
 		technique.setId("PEAKS");
 		technique.setName("Chromatography Peak Table");
-		technique.setUri("https://github.com/AnIML/techniques/blob/d749979fc21322b97c61e2efd6efe60cfa5a29be/chromatography-peak-table.atdd");
+		technique.setUri("https://animl.openchrom.net/chromatography-peak-table.atdd");
 		return technique;
 	}
 

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/io/MassSpectrumWriter.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/io/MassSpectrumWriter.java
@@ -140,7 +140,7 @@ public class MassSpectrumWriter implements IMassSpectraWriter {
 
 		TechniqueType technique = new TechniqueType();
 		technique.setName("Mass Spectrometry");
-		technique.setUri("https://github.com/AnIML/techniques/blob/db3fcd831c4fce00b647b7e6d8c21f753b76f361/mass-spec.atdd");
+		technique.setUri("https://animl.openchrom.net/mass-spec.atdd");
 		return technique;
 	}
 

--- a/openchrom/plugins/net.openchrom.wsd.converter.supplier.animl/src/net/openchrom/wsd/converter/supplier/animl/io/ChromatogramWriter.java
+++ b/openchrom/plugins/net.openchrom.wsd.converter.supplier.animl/src/net/openchrom/wsd/converter/supplier/animl/io/ChromatogramWriter.java
@@ -308,7 +308,7 @@ public class ChromatogramWriter extends AbstractChromatogramWSDWriter {
 
 		TechniqueType technique = new TechniqueType();
 		technique.setName("Chromatography");
-		technique.setUri("https://github.com/AnIML/techniques/blob/6e30b1e593e6df661a44ae2a9892b6198def0641/chromatography.atdd");
+		technique.setUri("https://animl.openchrom.net/chromatography.atdd");
 		return technique;
 	}
 
@@ -316,7 +316,7 @@ public class ChromatogramWriter extends AbstractChromatogramWSDWriter {
 
 		TechniqueType technique = new TechniqueType();
 		technique.setName("UV Trace");
-		technique.setUri("https://github.com/AnIML/techniques/blob/995bef06f90afba00a618239f40c6e591a1c0845/uv-vis-trace.atdd");
+		technique.setUri("https://animl.openchrom.net/uv-vis-trace.atdd");
 		return technique;
 	}
 
@@ -324,7 +324,7 @@ public class ChromatogramWriter extends AbstractChromatogramWSDWriter {
 
 		TechniqueType technique = new TechniqueType();
 		technique.setName("Spectrum");
-		technique.setUri("https://raw.githubusercontent.com/AnIML/techniques/995bef06f90afba00a618239f40c6e591a1c0845/uv-vis.atdd");
+		technique.setUri("https://animl.openchrom.net/uv-vis.atdd");
 		return technique;
 	}
 
@@ -332,7 +332,7 @@ public class ChromatogramWriter extends AbstractChromatogramWSDWriter {
 
 		TechniqueType technique = new TechniqueType();
 		technique.setName("Peak Table");
-		technique.setUri("https://github.com/AnIML/techniques/blob/d749979fc21322b97c61e2efd6efe60cfa5a29be/chromatography-peak-table.atdd");
+		technique.setUri("https://animl.openchrom.net/chromatography-peak-table.atdd");
 		return technique;
 	}
 


### PR DESCRIPTION
Instead of hot linking GitHub, I went with a proper CDN that also supports cross site scripting which web applications require. I reported the problem about upstream non-availability at https://github.com/AnIML/techniques/issues/24.