### PR TITLE
Trust the converter p2 update site by default

### DIFF
--- a/openchrom/products/net.openchrom.rcp.compilation.community.product/openchrom.compilation.community.product
+++ b/openchrom/products/net.openchrom.rcp.compilation.community.product/openchrom.compilation.community.product
@@ -23,6 +23,7 @@
 -Dosgi.instance.area=@user.home/OpenChrom/1.5.x
 -Dosgi.user.area=@user.home/.openchrom/1.5.x
 -Dorg.eclipse.update.reconcile=false
+-Dp2.trustedAuthorities=https://converter.openchrom.net
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread
       </vmArgsMac>


### PR DESCRIPTION
https://eclipse.dev/eclipse/news/4.28/platform.php#trusted-authorities saves a click.