### PR TITLE
Drop dependency from 2022-12 release

### DIFF
--- a/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
+++ b/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
@@ -13,10 +13,6 @@
 		<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<unit id="org.slf4j.api" version="0.0.0"/>
-		<repository location="https://download.eclipse.org/releases/2022-12/"/>
-	</location>
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/swtchart/integration/develop/repository"/>
 	</location>


### PR DESCRIPTION
as it is still included in the current one.