### PR TITLE
Fix identification results not getting saved when replacing peaks in Peak Review UI

### DIFF
--- a/openchrom/plugins/net.openchrom.csd.converter.supplier.cdf/src/net/openchrom/csd/converter/supplier/cdf/model/VendorChromatogramTSD.java
+++ b/openchrom/plugins/net.openchrom.csd.converter.supplier.cdf/src/net/openchrom/csd/converter/supplier/cdf/model/VendorChromatogramTSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Lablicate GmbH.
+ * Copyright (c) 2021, 2024 Lablicate GmbH.
  *
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -49,9 +49,8 @@ public class VendorChromatogramTSD extends AbstractChromatogramTSD {
 		return 0;
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
-	public void fireUpdate(IChromatogramSelection chromatogramSelection) {
+	public void fireUpdate(IChromatogramSelection<?, ?> chromatogramSelection) {
 
 	}
 }

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.cdf/src/net/openchrom/msd/converter/supplier/cdf/model/VendorChromatogramTSD.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.cdf/src/net/openchrom/msd/converter/supplier/cdf/model/VendorChromatogramTSD.java
@@ -49,9 +49,8 @@ public class VendorChromatogramTSD extends AbstractChromatogramTSD {
 		return 0;
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
-	public void fireUpdate(IChromatogramSelection chromatogramSelection) {
+	public void fireUpdate(IChromatogramSelection<?, ?> chromatogramSelection) {
 
 	}
 }

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.cms/src/net/openchrom/msd/converter/supplier/cms/model/CalibratedVendorMassSpectrum.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.cms/src/net/openchrom/msd/converter/supplier/cms/model/CalibratedVendorMassSpectrum.java
@@ -704,9 +704,8 @@ public class CalibratedVendorMassSpectrum extends CalibratedVendorLibraryMassSpe
 		return null;
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
-	public void setParentChromatogram(IChromatogram parentChromatogram) {
+	public void setParentChromatogram(IChromatogram<?> parentChromatogram) {
 
 	}
 

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/charts/PeakDetectorChart.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/charts/PeakDetectorChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -412,7 +412,6 @@ public class PeakDetectorChart extends ChromatogramPeakChart {
 						int stopRetentionTime = detectorRange.getRetentionTimeStop();
 						removeClosestPeak(peak, chromatogram, startRetentionTime, stopRetentionTime, replacePeakDelta);
 					}
-					//
 					chromatogram.addPeak(peak);
 					fireUpdate(peak);
 				}
@@ -445,11 +444,15 @@ public class PeakDetectorChart extends ChromatogramPeakChart {
 				}
 			}
 		}
-		/*
-		 * Delete the peak if a specific peak was found and
-		 * the peak top is inside the delta range of the existing peak.
-		 */
 		if(peakDelete != null) {
+			/*
+			 * Keep identification results.
+			 */
+			peakSource.getTargets().addAll(peakDelete.getTargets());
+			/*
+			 * Delete the peak if a specific peak was found and
+			 * the peak top is inside the delta range of the existing peak.
+			 */
 			int retentionTimeTarget = peakDelete.getPeakModel().getRetentionTimeAtPeakMaximum();
 			if(Math.abs(retentionTimeSource - retentionTimeTarget) <= replacePeakDelta) {
 				chromatogram.removePeak(peakDelete);

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/wizards/PeakReviewSupport.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/wizards/PeakReviewSupport.java
@@ -23,7 +23,6 @@ public class PeakReviewSupport {
 
 	public static final String DESCRIPTION = "Template Review UI";
 
-	@SuppressWarnings("rawtypes")
 	public void addSettings(Shell shell, ProcessReviewSettings processSettings) {
 
 		PeakReviewWizard wizard = new PeakReviewWizard(processSettings);
@@ -52,7 +51,7 @@ public class PeakReviewSupport {
 			wizardDialog.create();
 			wizardDialog.getShell().setBackgroundMode(SWT.INHERIT_DEFAULT);
 			//
-			IProcessingInfo processingInfo = processSettings.getProcessingInfo();
+			IProcessingInfo<?> processingInfo = processSettings.getProcessingInfo();
 			if(Window.OK == wizardDialog.open()) {
 				processingInfo.addInfoMessage(DESCRIPTION, "Successfully reviewed the peaks.");
 			} else {

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/chromatogram/ChromatogramReport.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/chromatogram/ChromatogramReport.java
@@ -87,7 +87,7 @@ public class ChromatogramReport extends AbstractChromatogramReportGenerator {
 
 	private List<IChromatogram<? extends IPeak>> getChromatogramList(IChromatogram<? extends IPeak> chromatogram) {
 
-		List<IChromatogram<? extends IPeak>> chromatograms = new ArrayList<IChromatogram<? extends IPeak>>();
+		List<IChromatogram<? extends IPeak>> chromatograms = new ArrayList<>();
 		chromatograms.add(chromatogram);
 		return chromatograms;
 	}

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/compiler/ReviewTemplateCompiler.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/compiler/ReviewTemplateCompiler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Lablicate GmbH.
+ * Copyright (c) 2022, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,7 +14,7 @@ package net.openchrom.xxd.process.supplier.templates.compiler;
 import java.io.File;
 import java.util.List;
 
-import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IPeakModel;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
@@ -43,8 +43,8 @@ public class ReviewTemplateCompiler implements ITemplateExport {
 			if(libraryInformation != null) {
 				ReviewSetting setting = new ReviewSetting();
 				setting.setPositionDirective(PositionDirective.RETENTION_TIME_MIN);
-				setting.setPositionStart((peakModel.getStartRetentionTime() - deltaLeft) / IChromatogram.MINUTE_CORRELATION_FACTOR);
-				setting.setPositionStop((peakModel.getStopRetentionTime() + deltaRight) / IChromatogram.MINUTE_CORRELATION_FACTOR);
+				setting.setPositionStart((peakModel.getStartRetentionTime() - deltaLeft) / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
+				setting.setPositionStop((peakModel.getStopRetentionTime() + deltaRight) / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
 				setting.setName(libraryInformation.getName());
 				setting.setCasNumber(libraryInformation.getCasNumber());
 				setting.setTraces(extractTraces(peak, numberTraces));

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/core/ReportWriter.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/core/ReportWriter.java
@@ -76,12 +76,12 @@ public class ReportWriter {
 		Collections.sort(traces);
 		//
 		try (PrintWriter printWriter = new PrintWriter(new FileWriter(file, append))) {
-			printResults(chromatograms, chromatogramReportSettings, printWriter, fileExists, traces, monitor);
+			printResults(chromatograms, chromatogramReportSettings, printWriter, fileExists, traces);
 			printWriter.flush();
 		}
 	}
 
-	private void printResults(List<IChromatogram<? extends IPeak>> chromatograms, ChromatogramReportSettings chromatogramReportSettings, PrintWriter printWriter, boolean fileExists, List<Integer> traces, IProgressMonitor monitor) {
+	private void printResults(List<IChromatogram<? extends IPeak>> chromatograms, ChromatogramReportSettings chromatogramReportSettings, PrintWriter printWriter, boolean fileExists, List<Integer> traces) {
 
 		Map<ReportSetting, List<IPeak>> sumResults = new HashMap<>();
 		int reports = 0;
@@ -489,7 +489,7 @@ public class ReportWriter {
 
 	private String getRetentionTimeMinutes(int retentionTime) {
 
-		return RETENTION_TIME_FORMAT.format(retentionTime / IChromatogram.MINUTE_CORRELATION_FACTOR);
+		return RETENTION_TIME_FORMAT.format(retentionTime / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
 	}
 
 	private double[] extractPeakAreas(List<IPeak> peaks) {

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/io/IdentifierExport.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/io/IdentifierExport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,6 +17,7 @@ import java.util.List;
 import org.eclipse.chemclipse.converter.chromatogram.AbstractChromatogramExportConverter;
 import org.eclipse.chemclipse.converter.chromatogram.IChromatogramExportConverter;
 import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IPeakModel;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
@@ -51,8 +52,8 @@ public class IdentifierExport extends AbstractChromatogramExportConverter implem
 			if(libraryInformation != null) {
 				IdentifierSetting setting = new IdentifierSetting();
 				setting.setPositionDirective(PositionDirective.RETENTION_TIME_MIN);
-				setting.setPositionStart((peakModel.getStartRetentionTime() - deltaLeft) / IChromatogram.MINUTE_CORRELATION_FACTOR);
-				setting.setPositionStop((peakModel.getStopRetentionTime() + deltaRight) / IChromatogram.MINUTE_CORRELATION_FACTOR);
+				setting.setPositionStart((peakModel.getStartRetentionTime() - deltaLeft) / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
+				setting.setPositionStop((peakModel.getStopRetentionTime() + deltaRight) / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
 				setting.setName(libraryInformation.getName());
 				setting.setCasNumber(libraryInformation.getCasNumber());
 				setting.setComments(libraryInformation.getComments());

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/io/ReferencerExport.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/io/ReferencerExport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,6 +17,7 @@ import java.util.List;
 import org.eclipse.chemclipse.converter.chromatogram.AbstractChromatogramExportConverter;
 import org.eclipse.chemclipse.converter.chromatogram.IChromatogramExportConverter;
 import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IPeakModel;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
@@ -62,8 +63,8 @@ public class ReferencerExport extends AbstractChromatogramExportConverter implem
 					 * If no identifier is available, use the retention time.
 					 */
 					if("".equals(identifier)) {
-						setting.setPositionStart((peakModel.getStartRetentionTime() - deltaLeft) / IChromatogram.MINUTE_CORRELATION_FACTOR);
-						setting.setPositionStop((peakModel.getStopRetentionTime() + deltaRight) / IChromatogram.MINUTE_CORRELATION_FACTOR);
+						setting.setPositionStart((peakModel.getStartRetentionTime() - deltaLeft) / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
+						setting.setPositionStop((peakModel.getStopRetentionTime() + deltaRight) / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
 					} else {
 						setting.setPositionStart(AbstractSetting.FULL_RETENTION_TIME);
 						setting.setPositionStop(AbstractSetting.FULL_RETENTION_TIME);

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/io/ReportExport.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/io/ReportExport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,6 +17,7 @@ import java.util.List;
 import org.eclipse.chemclipse.converter.chromatogram.AbstractChromatogramExportConverter;
 import org.eclipse.chemclipse.converter.chromatogram.IChromatogramExportConverter;
 import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IPeakModel;
 import org.eclipse.chemclipse.model.identifier.IIdentificationTarget;
@@ -50,8 +51,8 @@ public class ReportExport extends AbstractChromatogramExportConverter implements
 			if(libraryInformation != null) {
 				ReportSetting setting = new ReportSetting();
 				setting.setPositionDirective(PositionDirective.RETENTION_TIME_MIN);
-				setting.setPositionStart((peakModel.getStartRetentionTime() - deltaLeft) / IChromatogram.MINUTE_CORRELATION_FACTOR);
-				setting.setPositionStop((peakModel.getStopRetentionTime() + deltaRight) / IChromatogram.MINUTE_CORRELATION_FACTOR);
+				setting.setPositionStart((peakModel.getStartRetentionTime() - deltaLeft) / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
+				setting.setPositionStop((peakModel.getStopRetentionTime() + deltaRight) / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
 				setting.setName(libraryInformation.getName());
 				setting.setCasNumber(libraryInformation.getCasNumber());
 				reportSettings.add(setting);

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/io/StandardsExport.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/io/StandardsExport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,6 +17,7 @@ import java.util.List;
 import org.eclipse.chemclipse.converter.chromatogram.AbstractChromatogramExportConverter;
 import org.eclipse.chemclipse.converter.chromatogram.IChromatogramExportConverter;
 import org.eclipse.chemclipse.model.core.IChromatogram;
+import org.eclipse.chemclipse.model.core.IChromatogramOverview;
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.core.IPeakModel;
 import org.eclipse.chemclipse.model.quantitation.IInternalStandard;
@@ -51,8 +52,8 @@ public class StandardsExport extends AbstractChromatogramExportConverter impleme
 				for(IInternalStandard internalStandard : internalStandards) {
 					AssignerStandard setting = new AssignerStandard();
 					setting.setPositionDirective(PositionDirective.RETENTION_TIME_MIN);
-					setting.setPositionStart((peakModel.getStartRetentionTime() - deltaLeft) / IChromatogram.MINUTE_CORRELATION_FACTOR);
-					setting.setPositionStop((peakModel.getStopRetentionTime() + deltaRight) / IChromatogram.MINUTE_CORRELATION_FACTOR);
+					setting.setPositionStart((peakModel.getStartRetentionTime() - deltaLeft) / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
+					setting.setPositionStop((peakModel.getStopRetentionTime() + deltaRight) / IChromatogramOverview.MINUTE_CORRELATION_FACTOR);
 					setting.setName(internalStandard.getName());
 					setting.setConcentration(internalStandard.getConcentration());
 					setting.setConcentrationUnit(internalStandard.getConcentrationUnit());

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/model/DetectorSetting.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/model/DetectorSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Lablicate GmbH.
+ * Copyright (c) 2018, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -50,7 +50,7 @@ public class DetectorSetting extends AbstractSetting {
 
 	public boolean isIncludeBackground() {
 
-		return (PeakType.VV.equals(peakType)) ? true : false;
+		return (PeakType.VV.equals(peakType));
 	}
 
 	public String getTraces() {
@@ -105,12 +105,15 @@ public class DetectorSetting extends AbstractSetting {
 	@Override
 	public boolean equals(Object obj) {
 
-		if(this == obj)
+		if(this == obj) {
 			return true;
-		if(!super.equals(obj))
+		}
+		if(!super.equals(obj)) {
 			return false;
-		if(getClass() != obj.getClass())
+		}
+		if(getClass() != obj.getClass()) {
 			return false;
+		}
 		DetectorSetting other = (DetectorSetting)obj;
 		return Objects.equals(traces, other.traces);
 	}

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/peaks/CompensationQuantifier.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/peaks/CompensationQuantifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,7 +33,6 @@ import net.openchrom.xxd.process.supplier.templates.preferences.PreferenceSuppli
 import net.openchrom.xxd.process.supplier.templates.settings.CompensationQuantifierSettings;
 import net.openchrom.xxd.process.supplier.templates.settings.StandardsAssignerSettings;
 
-@SuppressWarnings("rawtypes")
 public class CompensationQuantifier extends AbstractPeakQuantifier implements IPeakQuantifier {
 
 	private static final String LABEL_ADJUSTED = " [adjusted]";
@@ -41,7 +40,7 @@ public class CompensationQuantifier extends AbstractPeakQuantifier implements IP
 	@Override
 	public IProcessingInfo<?> quantify(List<IPeak> peaks, IPeakQuantifierSettings settings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(peaks, settings);
+		IProcessingInfo<?> processingInfo = validate(peaks, settings);
 		if(!processingInfo.hasErrorMessages()) {
 			if(settings instanceof CompensationQuantifierSettings compensationQuantifierSettings) {
 				for(CompensationSetting compensationSetting : compensationQuantifierSettings.getCompensationSettingsList()) {
@@ -200,9 +199,9 @@ public class CompensationQuantifier extends AbstractPeakQuantifier implements IP
 		return quantitationEntries;
 	}
 
-	private IProcessingInfo validate(List<IPeak> peaks, IPeakQuantifierSettings settings) {
+	private IProcessingInfo<?> validate(List<IPeak> peaks, IPeakQuantifierSettings settings) {
 
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
 		if(peaks == null) {
 			processingInfo.addErrorMessage(StandardsAssignerSettings.DESCRIPTION, "The peaks selection must not be null.");
 		}

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/peaks/StandardsAssigner.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/peaks/StandardsAssigner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 Lablicate GmbH.
+ * Copyright (c) 2018, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,7 +33,6 @@ import net.openchrom.xxd.process.supplier.templates.settings.StandardsAssignerSe
 import net.openchrom.xxd.process.supplier.templates.support.RetentionIndexSupport;
 import net.openchrom.xxd.process.supplier.templates.util.TracesUtil;
 
-@SuppressWarnings("rawtypes")
 public class StandardsAssigner extends AbstractPeakQuantifier implements IPeakQuantifier {
 
 	private static final Logger logger = Logger.getLogger(StandardsAssigner.class);
@@ -41,7 +40,7 @@ public class StandardsAssigner extends AbstractPeakQuantifier implements IPeakQu
 	@Override
 	public IProcessingInfo<?> quantify(List<IPeak> peaks, IPeakQuantifierSettings settings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(peaks, settings);
+		IProcessingInfo<?> processingInfo = validate(peaks, settings);
 		if(!processingInfo.hasErrorMessages()) {
 			if(settings instanceof StandardsAssignerSettings standardsAssignerSettings) {
 				RetentionIndexMap retentionIndexMap = RetentionIndexSupport.getRetentionIndexMap(peaks);
@@ -127,9 +126,9 @@ public class StandardsAssigner extends AbstractPeakQuantifier implements IPeakQu
 		}
 	}
 
-	private IProcessingInfo validate(List<IPeak> peaks, IPeakQuantifierSettings settings) {
+	private IProcessingInfo<?> validate(List<IPeak> peaks, IPeakQuantifierSettings settings) {
 
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
 		if(peaks == null) {
 			processingInfo.addErrorMessage(StandardsAssignerSettings.DESCRIPTION, "The peaks selection must not be null.");
 		}

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/peaks/StandardsExtractor.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/peaks/StandardsExtractor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -37,7 +37,6 @@ import net.openchrom.xxd.process.supplier.templates.preferences.PreferenceSuppli
 import net.openchrom.xxd.process.supplier.templates.settings.StandardsAssignerSettings;
 import net.openchrom.xxd.process.supplier.templates.settings.StandardsExtractorSettings;
 
-@SuppressWarnings("rawtypes")
 public class StandardsExtractor extends AbstractPeakQuantifier implements IPeakQuantifier {
 
 	private static final Logger logger = Logger.getLogger(StandardsExtractor.class);
@@ -73,10 +72,9 @@ public class StandardsExtractor extends AbstractPeakQuantifier implements IPeakQ
 	@Override
 	public IProcessingInfo<?> quantify(List<IPeak> peaks, IPeakQuantifierSettings settings, IProgressMonitor monitor) {
 
-		IProcessingInfo processingInfo = validate(peaks, settings, monitor);
+		IProcessingInfo<?> processingInfo = validate(peaks, settings);
 		if(!processingInfo.hasErrorMessages()) {
-			if(settings instanceof StandardsExtractorSettings) {
-				StandardsExtractorSettings extractorSettings = (StandardsExtractorSettings)settings;
+			if(settings instanceof StandardsExtractorSettings extractorSettings) {
 				assignPeaks(peaks, extractorSettings);
 			} else {
 				processingInfo.addErrorMessage(StandardsAssignerSettings.DESCRIPTION, "The settings instance is wrong.");
@@ -88,7 +86,7 @@ public class StandardsExtractor extends AbstractPeakQuantifier implements IPeakQ
 	@Override
 	public IProcessingInfo<?> quantify(IPeak peak, IPeakQuantifierSettings settings, IProgressMonitor monitor) {
 
-		List<IPeak> peaks = new ArrayList<IPeak>();
+		List<IPeak> peaks = new ArrayList<>();
 		peaks.add(peak);
 		return quantify(peaks, settings, monitor);
 	}
@@ -96,7 +94,7 @@ public class StandardsExtractor extends AbstractPeakQuantifier implements IPeakQ
 	@Override
 	public IProcessingInfo<?> quantify(IPeak peak, IProgressMonitor monitor) {
 
-		List<IPeak> peaks = new ArrayList<IPeak>();
+		List<IPeak> peaks = new ArrayList<>();
 		peaks.add(peak);
 		StandardsExtractorSettings settings = getSettings();
 		return quantify(peaks, settings, monitor);
@@ -119,7 +117,7 @@ public class StandardsExtractor extends AbstractPeakQuantifier implements IPeakQ
 	private void assignPeaks(List<? extends IPeak> peaks, StandardsExtractorSettings extractorSettings) {
 
 		try {
-			IChromatogram chromatogram = getChromatogram(peaks);
+			IChromatogram<?> chromatogram = getChromatogram(peaks);
 			if(chromatogram != null) {
 				Standard standard = extractReferenceId(chromatogram.getMiscInfo());
 				if(isValidStandard(standard)) {
@@ -167,7 +165,7 @@ public class StandardsExtractor extends AbstractPeakQuantifier implements IPeakQ
 		return null;
 	}
 
-	private IChromatogram getChromatogram(List<? extends IPeak> peaks) {
+	private IChromatogram<?> getChromatogram(List<? extends IPeak> peaks) {
 
 		for(IPeak peak : peaks) {
 			if(peak instanceof IChromatogramPeakCSD chromatogramPeakCSD) {
@@ -197,9 +195,9 @@ public class StandardsExtractor extends AbstractPeakQuantifier implements IPeakQ
 		return null;
 	}
 
-	private IProcessingInfo validate(List<IPeak> peaks, IPeakQuantifierSettings settings, IProgressMonitor monitor) {
+	private IProcessingInfo<?> validate(List<IPeak> peaks, IPeakQuantifierSettings settings) {
 
-		IProcessingInfo processingInfo = new ProcessingInfo();
+		IProcessingInfo<?> processingInfo = new ProcessingInfo<>();
 		if(peaks == null) {
 			processingInfo.addErrorMessage(StandardsAssignerSettings.DESCRIPTION, "The peaks selection must not be null.");
 		}


### PR DESCRIPTION
This way you are also not losing internal reference numbers.