### PR TITLE
Fix manual classification get in the way of target copying in Peak Review UI

### DIFF
--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/support/ReviewSupport.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/support/ReviewSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2024 Lablicate GmbH.
  * 
  * All rights reserved.
  * This program and the accompanying materials are made available under the
@@ -54,20 +54,19 @@ public class ReviewSupport {
 	public static void setReview(IPeak peak, ReviewSetting reviewSetting, boolean setTarget, boolean reviewSuccessful) {
 
 		if(peak != null) {
-			//
 			IIdentificationTarget identificationTarget = null;
 			if(reviewSetting != null && setTarget) {
 				String name = reviewSetting.getName();
 				String casNumber = reviewSetting.getCasNumber();
 				identificationTarget = IIdentificationTarget.createDefaultTarget(name, casNumber, TargetValidator.IDENTIFIER);
 			}
-			//
 			if(reviewSuccessful) {
 				/*
 				 * OK
 				 */
 				peak.addClassifier(ReviewSetting.CLASSIFIER_REVIEW_OK);
 				if(identificationTarget != null) {
+					peak.getTargets().clear();
 					peak.getTargets().add(identificationTarget);
 				}
 			} else {


### PR DESCRIPTION
https://github.com/OpenChrom/openchrom/pull/531 broke the workflow when the review sets its own 100 % target based on manually input CAS and name. It does not make sense to mix both. Now you can either enable the manual setting or disable it and get replaced peaks with the previous identification targets.