### PR TITLE
Set the .app name on macOS

### DIFF
--- a/openchrom/pom.xml
+++ b/openchrom/pom.xml
@@ -221,6 +221,13 @@
 									<linux>tar.gz</linux>
 									<macosx>tar.gz</macosx>
 								</formats>
+								<products>
+									<product>
+										<rootFolders>
+											<macosx>OpenChrom.app</macosx>
+										</rootFolders>
+									</product>
+								</products>
 							</configuration>
 						</execution>
 					</executions>


### PR DESCRIPTION
as it defaults to `Eclipse.app`, which is weird as people have to type that when searching with Finder.