### PR TITLE
Fixed template report always opening system editor

### DIFF
--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/plugin.xml
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/plugin.xml
@@ -331,4 +331,11 @@
             id="net.openchrom.xxd.process.supplier.templates.peakIntegrator">
       </icon>
    </extension>
+   <extension
+         point="org.eclipse.chemclipse.xxd.process.ui.menu.icon">
+      <icon
+            class="net.openchrom.xxd.process.supplier.templates.ui.icon.TemplateMenuIcon"
+            id="org.eclipse.chemclipse.chromatogram.xxd.report.supplier.openchrom.templateChromatogramReport">
+      </icon>
+   </extension>
 </plugin>

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/Activator.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/Activator.java
@@ -88,9 +88,7 @@ public class Activator extends AbstractActivatorUI {
 					if(object instanceof File file) {
 						if(file.exists()) {
 							if(IChemClipseEvents.TOPIC_PROCESSING_FILE_CREATED.equals(topic)) {
-								if(PreferenceSupplier.isOpenReportAfterProcessing()) {
-									SystemEditor.open(file);
-								}
+								SystemEditor.open(file);
 							}
 						}
 					}

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/preferences/PageChromatogramReport.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/preferences/PageChromatogramReport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2024 Lablicate GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -35,10 +35,12 @@ public class PageChromatogramReport extends FieldEditorPreferencePage implements
 	 * GUI blocks needed to manipulate various types of preferences. Each field
 	 * editor knows how to save and restore itself.
 	 */
+	@Override
 	public void createFieldEditors() {
 
 		addField(new ReportFieldEditor(PreferenceSupplier.P_CHROMATOGRAM_REPORT_LIST, "", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_REPORT_REFERENCED_CHROMATOGRAMS, "Report Referenced Chromatograms", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_OPEN_REPORT_AFTER_PROCESSING, "Open report after processing", getFieldEditorParent()));
 	}
 
 	/*
@@ -46,6 +48,7 @@ public class PageChromatogramReport extends FieldEditorPreferencePage implements
 	 * @see
 	 * org.eclipse.ui.IWorkbenchPreferencePage#init(org.eclipse.ui.IWorkbench)
 	 */
+	@Override
 	public void init(IWorkbench workbench) {
 
 	}

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/preferences/PreferencePage.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/preferences/PreferencePage.java
@@ -59,7 +59,6 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_DETECTOR_SETTINGS_SORT, "Sort Detector Settings", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_REVIEW_SETTINGS_SORT, "Sort Review Settings", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_REPORT_SETTINGS_SORT, "Sort Report Settings", getFieldEditorParent()));
-		addField(new BooleanFieldEditor(PreferenceSupplier.P_OPEN_REPORT_AFTER_PROCESSING, "Open report after processing", getFieldEditorParent()));
 	}
 
 	/*

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/chromatogram/ChromatogramReport.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/chromatogram/ChromatogramReport.java
@@ -50,7 +50,9 @@ public class ChromatogramReport extends AbstractChromatogramReportGenerator {
 					ReportWriter reportWriter = new ReportWriter();
 					reportWriter.generate(file, append, chromatograms, reportSettings, monitor);
 					processingInfo.setProcessingResult(file);
-					UpdateNotifier.update(IChemClipseEvents.TOPIC_PROCESSING_FILE_CREATED, file);
+					if(PreferenceSupplier.isOpenReportAfterProcessing()) {
+						UpdateNotifier.update(IChemClipseEvents.TOPIC_PROCESSING_FILE_CREATED, file);
+					}
 				} catch(IOException e) {
 					logger.warn(e);
 					processingInfo.addErrorMessage(DESCRIPTION, "The report couldn't be created. An error occured.");
@@ -59,7 +61,6 @@ public class ChromatogramReport extends AbstractChromatogramReportGenerator {
 				logger.warn("The settings are not of type: " + ChromatogramReportSettings.class);
 			}
 		}
-		//
 		return processingInfo;
 	}
 


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/OpenChrom/openchrom/commit/c2a347095afb2962fd45ca3f88f853aa72f5e5fb and adds some polish.