### PR TITLE
Adjust interface of analysisSegment service to legacy implementation

### DIFF
--- a/openchrom/plugins/net.openchrom.xxd.base.ui/src/net/openchrom/xxd/base/ui/services/IAnalysisSegmentService.java
+++ b/openchrom/plugins/net.openchrom.xxd.base.ui/src/net/openchrom/xxd/base/ui/services/IAnalysisSegmentService.java
@@ -13,8 +13,7 @@ package net.openchrom.xxd.base.ui.services;
 
 import java.util.List;
 
-import org.eclipse.chemclipse.model.core.IChromatogram;
-import org.eclipse.chemclipse.model.core.IScan;
+import org.eclipse.chemclipse.model.selection.IChromatogramSelection;
 import org.eclipse.chemclipse.model.support.IAnalysisSegment;
 import org.eclipse.chemclipse.model.types.DataType;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
@@ -31,7 +30,7 @@ public interface IAnalysisSegmentService {
 
 	DataType getDataType();
 
-	IProcessingInfo<List<IAnalysisSegment>> calculate(IChromatogram<?> chromatogram, List<? extends IScan> scans, IProgressMonitor monitor);
+	IProcessingInfo<List<IAnalysisSegment>> calculate(IChromatogramSelection<?, ?> chromatogram, IProgressMonitor monitor);
 
 	Class<? extends IWorkbenchPreferencePage> getPreferencePage();
 }


### PR DESCRIPTION
For the moment, the service interface should be adjusted to work with the legacy implementation until further harmonisation of the mcr-ar toolchain has been done.