### PR TITLE
Reduce Gaussian curve underfitting during peak transfer 

### DIFF
--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/peaks/PeakTransfer.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/peaks/PeakTransfer.java
@@ -355,6 +355,9 @@ public class PeakTransfer extends AbstractPeakDetector implements IPeakDetectorM
 		}
 		while(!isWithinBounds(peakSink, chromatogramCSD)) {
 			sigma = sigma - 0.1;
+			if(sigma < 0.1) {
+				return null;
+			}
 			gaussian = new Gaussian(intensity, centerScan, sigma);
 			peakSink = createDefaultGaussPeakNormal(chromatogramCSD, startRetentionTime, stopRetentionTime, gaussian, intensity);
 			if(peakSink == null) {

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/peaks/PeakTransfer.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/peaks/PeakTransfer.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 
 import org.apache.commons.math3.analysis.function.Gaussian;
 import org.eclipse.chemclipse.chromatogram.csd.peak.detector.core.IPeakDetectorCSD;
@@ -146,6 +147,7 @@ public class PeakTransfer extends AbstractPeakDetector implements IPeakDetectorM
 		groups.addAll(peakGroups.keySet());
 		Collections.sort(groups);
 		monitor.beginTask("Transfer Peaks", peaks.size());
+		CountDownLatch latch = new CountDownLatch(peaks.size());
 		for(int group : groups) {
 			List<IPeak> peakz = peakGroups.get(group);
 			if(peakz.size() == 1) {
@@ -154,21 +156,37 @@ public class PeakTransfer extends AbstractPeakDetector implements IPeakDetectorM
 				 */
 				IPeak peak = peakz.get(0);
 				double percentageIntensity = getPercentageIntensity(peak);
-				transfer(peak, percentageIntensity, chromatogramSink, peakTransferSettings);
-				monitor.worked(1);
+				Thread.ofVirtual().start(() -> {
+					try {
+						transfer(peak, percentageIntensity, chromatogramSink, peakTransferSettings);
+					} finally {
+						monitor.worked(1);
+						latch.countDown();
+					}
+				});
 			} else {
 				/*
 				 * Peak Group
 				 */
 				for(IPeak peak : peakz) {
-					try {
-						transfer(peak, chromatogramSink, peakTransferSettings);
-					} catch(Exception e) {
-						logger.warn(e);
-					}
-					monitor.worked(1);
+					Thread.ofVirtual().start(() -> {
+						try {
+							transfer(peak, chromatogramSink, peakTransferSettings);
+						} catch(Exception e) {
+							logger.warn(e);
+						} finally {
+							monitor.worked(1);
+							latch.countDown();
+						}
+					});
 				}
 			}
+		}
+		try {
+			latch.await();
+		} catch(InterruptedException e) {
+			logger.error(e);
+			Thread.currentThread().interrupt();
 		}
 	}
 

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/peaks/PeakTransfer.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/peaks/PeakTransfer.java
@@ -354,7 +354,7 @@ public class PeakTransfer extends AbstractPeakDetector implements IPeakDetectorM
 			return null;
 		}
 		while(!isWithinBounds(peakSink, chromatogramCSD)) {
-			sigma = sigma / 2;
+			sigma = sigma - 0.1;
 			gaussian = new Gaussian(intensity, centerScan, sigma);
 			peakSink = createDefaultGaussPeakNormal(chromatogramCSD, startRetentionTime, stopRetentionTime, gaussian, intensity);
 			if(peakSink == null) {


### PR DESCRIPTION
This is a followup to https://github.com/OpenChrom/openchrom/pull/574 which reduces the sigma step size for a better fit vs. slower compute tradeoff. To offset this, the peak transfer is now multithreaded and for slow impossible fits I abort earlier, so the whole process does not have to wait when it is already futile.