### PR TITLE
Fetch more dependencies from Eclipse

### DIFF
--- a/openchrom/features/net.openchrom.platform.feature/feature.xml
+++ b/openchrom/features/net.openchrom.platform.feature/feature.xml
@@ -212,10 +212,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="wrapped.org.jdom.jdom2"
-         version="0.0.0"/>
-
-   <plugin
          id="javax.vecmath"
          version="0.0.0"/>
 
@@ -453,6 +449,10 @@
 
    <plugin
          id="org.apache.logging.log4j.core"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.jdom2"
          version="0.0.0"/>
 
 </feature>

--- a/openchrom/plugins/net.openchrom.csd.converter.supplier.cdf/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.csd.converter.supplier.cdf/META-INF/MANIFEST.MF
@@ -19,9 +19,9 @@ Require-Bundle: org.eclipse.core.runtime,
  wrapped.edu.ucar.cdm-core;bundle-version="5.5.3",
  wrapped.edu.ucar.udunits;bundle-version="5.5.3",
  com.google.guava;bundle-version="30.1.0",
- com.google.protobuf;bundle-version="3.21.5",
  wrapped.com.google.re2j.re2j;bundle-version="1.7.0",
- wrapped.org.jdom.jdom2;bundle-version="2.0.6"
+ com.google.protobuf;bundle-version="2.4.0",
+ org.jdom2;bundle-version="2.0.6"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: net.openchrom.csd.converter.supplier.cdf.model,

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.cdf/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.cdf/META-INF/MANIFEST.MF
@@ -16,11 +16,11 @@ Require-Bundle: org.eclipse.core.runtime,
  wrapped.edu.ucar.cdm-core;bundle-version="5.5.3",
  wrapped.edu.ucar.udunits;bundle-version="5.5.3",
  com.google.guava;bundle-version="30.1.0",
- com.google.protobuf;bundle-version="3.21.5",
  wrapped.com.google.re2j.re2j;bundle-version="1.7.0",
- wrapped.org.jdom.jdom2;bundle-version="2.0.6",
  org.eclipse.chemclipse.tsd.converter;bundle-version="0.9.0",
- org.eclipse.chemclipse.tsd.model;bundle-version="0.9.0"
+ org.eclipse.chemclipse.tsd.model;bundle-version="0.9.0",
+ com.google.protobuf;bundle-version="2.4.0",
+ org.jdom2;bundle-version="2.0.6"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: OpenChrom

--- a/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
+++ b/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
@@ -6,6 +6,8 @@
 		<repository location="https://download.eclipse.org/releases/2025-03/"/>
 		<unit id="org.eclipse.equinox.sdk.feature.group"/>
 		<unit id="org.eclipse.sdk.feature.group"/>
+		<unit id="com.google.protobuf"/>
+		<unit id="org.jdom2"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<repository location="https://download.eclipse.org/cbi/updates/license/1.0.0.v20131003-1638/"/>
@@ -144,29 +146,9 @@
 	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
 		<dependencies>
 			<dependency>
-				<groupId>com.google.protobuf</groupId>
-				<artifactId>protobuf-java</artifactId>
-				<version>3.21.5</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
-		<dependencies>
-			<dependency>
 				<groupId>com.google.re2j</groupId>
 				<artifactId>re2j</artifactId>
 				<version>1.7</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>org.jdom</groupId>
-				<artifactId>jdom2</artifactId>
-				<version>2.0.6.1</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
* https://download.eclipse.org/releases/2025-03/202503121000/buildInfo/archive/download.eclipse.org/releases/2025-03/202503121000/index/org.jdom2_2.0.6.v20230720-0727.html
* https://download.eclipse.org/releases/2025-03/202503121000/buildInfo/archive/download.eclipse.org/releases/2025-03/202503121000/index/com.google.protobuf_2.4.0.v201105131100.html