### PR TITLE
Fix wonky peak review selection on split peaks

### DIFF
--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/PeakStatusLabelProvider.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/PeakStatusLabelProvider.java
@@ -33,12 +33,12 @@ public class PeakStatusLabelProvider extends AbstractChemClipseLabelProvider {
 	public static final String NAME = "Name";
 	public static final String AREA = "Area";
 	public static final String CLASSIFICATION = "Classification";
-	//
+
 	public static final int INDEX_NAME = 2;
 	public static final int INDEX_CLASSIFICATION = 4;
-	//
+
 	private DecimalFormat decimalFormat = ValueFormat.getDecimalFormatEnglish("0.0##");
-	//
+
 	public static final String[] TITLES = { //
 			START_RETENTION_TIME, //
 			STOP_RETENTION_TIME, //

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/support/ReviewSupport.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/support/ReviewSupport.java
@@ -125,8 +125,8 @@ public class ReviewSupport {
 			 */
 			String namePeak = libraryInformation.getName();
 			String nameReview = reviewSetting.getName();
-			if(!namePeak.isEmpty() && namePeak.equals(nameReview)) {
-				return true;
+			if(!namePeak.isEmpty()) {
+				return namePeak.equals(nameReview);
 			}
 			/*
 			 * CAS

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/PeakReviewListUI.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/PeakReviewListUI.java
@@ -30,7 +30,7 @@ public class PeakReviewListUI extends AbstractTemplateListUI {
 
 	private static final String[] TITLES = PeakReviewLabelProvider.TITLES;
 	private static final int[] BOUNDS = PeakReviewLabelProvider.BOUNDS;
-	//
+
 	private PeakReviewLabelProvider labelProvider = new PeakReviewLabelProvider();
 	private PeakReviewComparator tableComparator = new PeakReviewComparator();
 	private PeakReviewFilter listFilter = new PeakReviewFilter();
@@ -46,6 +46,7 @@ public class PeakReviewListUI extends AbstractTemplateListUI {
 		createColumns(enableEditPositionDirective);
 	}
 
+	@Override
 	public void setSearchText(String searchText, boolean caseSensitive) {
 
 		listFilter.setSearchText(searchText, caseSensitive);

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/PeakStatusListUI.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/PeakStatusListUI.java
@@ -33,7 +33,7 @@ public class PeakStatusListUI extends ExtendedTableViewer {
 
 	private static final String[] TITLES = PeakStatusLabelProvider.TITLES;
 	private static final int[] BOUNDS = PeakStatusLabelProvider.BOUNDS;
-	//
+
 	private PeakStatusLabelProvider labelProvider = new PeakStatusLabelProvider();
 	private PeakStatusComparator tableComparator = new PeakStatusComparator();
 	private ReviewSetting reviewSetting;

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/peaks/ExtendedPeakReviewUI.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/peaks/ExtendedPeakReviewUI.java
@@ -54,17 +54,17 @@ import net.openchrom.xxd.process.supplier.templates.ui.swt.PeakStatusListUI;
 public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 
 	private static final String MENU_CATEGORY_PEAKS = "Peaks";
-	//
+
 	private ReviewController controller;
 	private Text textTarget;
-	//
+
 	private AtomicReference<PeakStatusListUI> peakStatusControl = new AtomicReference<>();
 	private Button buttonToolbarInfo;
 	private AtomicReference<InformationUI> toolbarInfo = new AtomicReference<>();
-	//
+
 	private List<IPeak> peaks;
 	private ReviewSetting reviewSetting;
-	//
+
 	private DecimalFormat decimalFormat = ValueFormat.getDecimalFormatEnglish("0.0000");
 
 	public ExtendedPeakReviewUI(Composite parent, int style) {
@@ -77,7 +77,7 @@ public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 
 		this.reviewSetting = reviewSetting;
 		this.peaks = peaks;
-		//
+
 		update(reviewSetting);
 		peakStatusControl.get().setInput(peaks);
 		if(peak != null) {
@@ -85,7 +85,7 @@ public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 		} else {
 			autoSelectBestMatch();
 		}
-		//
+
 		updateSelection(false);
 	}
 
@@ -98,11 +98,11 @@ public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 
 		GridLayout gridLayout = new GridLayout(1, true);
 		setLayout(gridLayout);
-		//
+
 		createToolbarMain(this);
 		createTablePeaks(this);
 		createToolbarInfo(this);
-		//
+
 		initialize();
 	}
 
@@ -116,7 +116,7 @@ public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 		Composite composite = new Composite(parent, SWT.NONE);
 		composite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		composite.setLayout(new GridLayout(5, false));
-		//
+
 		textTarget = createTargetText(composite);
 		buttonToolbarInfo = createButtonToggleToolbar(composite, toolbarInfo, IMAGE_INFO, TOOLTIP_INFO);
 		createMarkPeakButton(composite);
@@ -128,7 +128,7 @@ public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 
 		Text text = new Text(parent, SWT.BORDER | SWT.READ_ONLY);
 		text.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		//
+
 		return text;
 	}
 
@@ -192,7 +192,7 @@ public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 		PeakStatusListUI peakStatusListUI = new PeakStatusListUI(parent, SWT.BORDER | SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION);
 		Table table = peakStatusListUI.getTable();
 		table.setLayoutData(new GridData(GridData.FILL_BOTH));
-		//
+
 		table.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -201,7 +201,7 @@ public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 				updateSelection(false);
 			}
 		});
-		//
+
 		table.addMouseListener(new MouseAdapter() {
 
 			@Override
@@ -218,7 +218,7 @@ public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 		addDeleteMenuEntry(shell, tableSettings);
 		addKeyEventProcessors(shell, tableSettings);
 		peakStatusListUI.applySettings(tableSettings);
-		//
+
 		peakStatusControl.set(peakStatusListUI);
 	}
 
@@ -226,7 +226,7 @@ public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 
 		InformationUI informationUI = new InformationUI(parent, SWT.NONE);
 		informationUI.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		//
+
 		toolbarInfo.set(informationUI);
 	}
 
@@ -254,7 +254,6 @@ public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 		});
 	}
 
-	@SuppressWarnings("rawtypes")
 	private void deletePeaks(Shell shell) {
 
 		if(reviewSetting != null) {
@@ -266,14 +265,14 @@ public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 				 * Delete Peaks
 				 */
 				List<IPeak> peaksToDelete = new ArrayList<>();
-				Iterator iterator = peakStatusControl.get().getStructuredSelection().iterator();
+				Iterator<?> iterator = peakStatusControl.get().getStructuredSelection().iterator();
 				while(iterator.hasNext()) {
 					Object object = iterator.next();
 					if(object instanceof IPeak peak) {
 						peaksToDelete.add(peak);
 					}
 				}
-				//
+
 				controller.deletePeaks(messageBox.getParent(), peaksToDelete);
 			}
 		}
@@ -392,7 +391,7 @@ public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 			 * Peak -> Quant
 			 */
 			List<IQuantitationEntry> quantitationEntries = peak.getQuantitationEntries();
-			//
+
 			builder.append("Quantitations");
 			builder.append(" ");
 			builder.append("(");
@@ -400,7 +399,7 @@ public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 			builder.append(")");
 			builder.append(":");
 			builder.append(" ");
-			//
+
 			if(!quantitationEntries.isEmpty()) {
 				IQuantitationEntry quantitationEntry = peak.getQuantitationEntries().get(0);
 				builder.append(quantitationEntry.getName());
@@ -413,7 +412,7 @@ public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 			}
 		}
 		toolbarInfo.get().setText(builder.toString());
-		//
+
 		if(controller != null) {
 			List<IPeak> peaks = getSelectedPeaks();
 			if(updateChart) {

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/peaks/ExtendedPeakReviewUI.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/peaks/ExtendedPeakReviewUI.java
@@ -336,7 +336,9 @@ public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 			for(int i = 0; i < peaks.size(); i++) {
 				if(peaks.get(i) == peak) {
 					if(ReviewSupport.isCompoundAvailable(peak.getTargets(), reviewSetting)) {
-						peakStatusControl.get().getTable().select(i);
+						Table table = peakStatusControl.get().getTable();
+						table.deselectAll();
+						table.select(i);
 						break exitloop;
 					}
 				}
@@ -352,7 +354,9 @@ public class ExtendedPeakReviewUI extends Composite implements IExtendedPartUI {
 				for(int i = 0; i < peaks.size(); i++) {
 					IPeak peak = peaks.get(i);
 					if(ReviewSupport.isCompoundAvailable(peak.getTargets(), reviewSetting)) {
-						peakStatusControl.get().getTable().select(i);
+						Table table = peakStatusControl.get().getTable();
+						table.deselectAll();
+						table.select(i);
 						break exitloop;
 					}
 				}

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/peaks/PeakReviewControl.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/peaks/PeakReviewControl.java
@@ -24,7 +24,7 @@ import net.openchrom.xxd.process.supplier.templates.ui.wizards.ProcessReviewSett
 public class PeakReviewControl extends Composite {
 
 	private ReviewController controller = new ReviewController(this);
-	//
+
 	private SashForm sashFormMain;
 	private SashForm sashFormDetails;
 	private boolean showComparisonUI = false;
@@ -70,29 +70,29 @@ public class PeakReviewControl extends Composite {
 
 		setLayout(new FillLayout());
 		SashForm sashForm = new SashForm(this, SWT.VERTICAL);
-		//
+
 		createNavigateSection(sashForm);
 		sashFormDetails = createDetailsSection(sashForm);
-		//
+
 		return sashForm;
 	}
 
 	private SashForm createNavigateSection(Composite parent) {
 
 		SashForm sashForm = new SashForm(parent, SWT.HORIZONTAL);
-		//
+
 		createReviewSection(sashForm);
 		controller.createPeakDetectorChart(sashForm);
-		//
+
 		sashForm.setWeights(350, 650);
-		//
+
 		return sashForm;
 	}
 
 	private void createReviewSection(Composite composite) {
 
 		SashForm sashForm = new SashForm(composite, SWT.VERTICAL);
-		//
+
 		controller.createProcessReviewUI(sashForm);
 		controller.createExtendedPeaksUI(sashForm);
 	}
@@ -100,11 +100,11 @@ public class PeakReviewControl extends Composite {
 	private SashForm createDetailsSection(Composite parent) {
 
 		SashForm sashForm = new SashForm(parent, SWT.HORIZONTAL);
-		//
+
 		controller.createExtendedTargetsUI(sashForm);
 		controller.createExtendedComparisonUI(sashForm);
 		controller.createExtendedPeakTracesUI(sashForm);
-		//
+
 		return sashForm;
 	}
 }

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/peaks/ProcessReviewUI.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/peaks/ProcessReviewUI.java
@@ -53,11 +53,11 @@ import net.openchrom.xxd.process.supplier.templates.ui.wizards.ProcessReviewSett
 public class ProcessReviewUI extends Composite {
 
 	private ReviewController controller;
-	//
+
 	private ComboViewer comboViewerVisibility;
 	private Composite toolbarSearch;
 	private PeakReviewListUI peakReviewListUI;
-	//
+
 	private ProcessReviewSettings processSettings;
 
 	public ProcessReviewUI(Composite parent, int style) {
@@ -96,11 +96,11 @@ public class ProcessReviewUI extends Composite {
 
 		GridLayout gridLayout = new GridLayout(1, true);
 		setLayout(gridLayout);
-		//
+
 		createToolbarMain(this);
 		toolbarSearch = createToolbarSearch(this);
 		peakReviewListUI = createTable(this);
-		//
+
 		PartSupport.setCompositeVisibility(toolbarSearch, false);
 	}
 
@@ -111,7 +111,7 @@ public class ProcessReviewUI extends Composite {
 		gridData.horizontalAlignment = SWT.END;
 		composite.setLayoutData(gridData);
 		composite.setLayout(new GridLayout(5, false));
-		//
+
 		createToggleToolbarSearch(composite);
 		createButtonVisibilityDetails(composite);
 		comboViewerVisibility = createComboViewerVisibility(composite);
@@ -131,7 +131,7 @@ public class ProcessReviewUI extends Composite {
 				peakReviewListUI.setSearchText(searchText, caseSensitive);
 			}
 		});
-		//
+
 		return searchSupportUI;
 	}
 
@@ -140,7 +140,7 @@ public class ProcessReviewUI extends Composite {
 		Button button = new Button(parent, SWT.PUSH);
 		button.setText("");
 		adjustButtonVisibilityDetails(button);
-		//
+
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -153,7 +153,7 @@ public class ProcessReviewUI extends Composite {
 				}
 			}
 		});
-		//
+
 		return button;
 	}
 
@@ -187,7 +187,7 @@ public class ProcessReviewUI extends Composite {
 				}
 			}
 		});
-		//
+
 		return button;
 	}
 
@@ -207,7 +207,7 @@ public class ProcessReviewUI extends Composite {
 				return null;
 			}
 		});
-		//
+
 		combo.setToolTipText("Select the visibility option.");
 		GridData gridData = new GridData();
 		gridData.widthHint = 150;
@@ -224,7 +224,7 @@ public class ProcessReviewUI extends Composite {
 				}
 			}
 		});
-		//
+
 		return comboViewer;
 	}
 
@@ -233,7 +233,7 @@ public class ProcessReviewUI extends Composite {
 		Button button = new Button(parent, SWT.PUSH);
 		button.setText("");
 		adjustDetectorButton(button);
-		//
+
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -244,7 +244,7 @@ public class ProcessReviewUI extends Composite {
 				updateSelection();
 			}
 		});
-		//
+
 		return button;
 	}
 
@@ -273,7 +273,7 @@ public class ProcessReviewUI extends Composite {
 				PreferenceManager preferenceManager = new PreferenceManager();
 				preferenceManager.addToRoot(new PreferenceNode("1", new PagePeakReview()));
 				preferenceManager.addToRoot(new PreferenceNode("2", new PreferencePage()));
-				//
+
 				PreferenceDialog preferenceDialog = new PreferenceDialog(e.display.getActiveShell(), preferenceManager);
 				preferenceDialog.create();
 				preferenceDialog.setMessage("Settings");
@@ -293,7 +293,7 @@ public class ProcessReviewUI extends Composite {
 		PeakReviewListUI peakReviewListUI = new PeakReviewListUI(parent, SWT.BORDER, false);
 		Table table = peakReviewListUI.getTable();
 		table.setLayoutData(new GridData(GridData.FILL_BOTH));
-		//
+
 		peakReviewListUI.setUpdateListener(new IUpdateListener() {
 
 			@Override
@@ -302,7 +302,7 @@ public class ProcessReviewUI extends Composite {
 				updateSelection();
 			}
 		});
-		//
+
 		table.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -311,7 +311,7 @@ public class ProcessReviewUI extends Composite {
 				updateSelection();
 			}
 		});
-		//
+
 		return peakReviewListUI;
 	}
 
@@ -363,7 +363,7 @@ public class ProcessReviewUI extends Composite {
 				Visibility[] items = Visibility.values();
 				comboViewerVisibility.setInput(items);
 				Visibility visibility = PreferenceSupplier.getReviewVisibility();
-				//
+
 				exitloop:
 				for(int i = 0; i < items.length; i++) {
 					Visibility item = items[i];

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/peaks/ReviewController.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/peaks/ReviewController.java
@@ -49,18 +49,18 @@ import net.openchrom.xxd.process.supplier.templates.util.PeakDetectorListUtil;
 public class ReviewController {
 
 	private static final String DETECTOR_DESCRIPTION = "Manual (Review UI)";
-	//
+
 	private ProcessReviewUI processReviewUI;
 	private PeakDetectorChart peakDetectorChart;
 	private ExtendedPeakReviewUI extendedPeakReviewUI;
 	private ExtendedTargetsUI extendedTargetsUI;
 	private ExtendedComparisonUI extendedComparisonUI;
 	private ExtendedPeakTracesUI extendedPeakTracesUI;
-	//
+
 	private PeakDetectorListUtil peakDetectorListUtil = new PeakDetectorListUtil();
 	private ProcessReviewSettings processSettings;
 	private ReviewSetting reviewSetting = null;
-	//
+
 	private PeakReviewControl peakReviewControl;
 
 	public ReviewController(PeakReviewControl peakReviewControl) {
@@ -72,7 +72,7 @@ public class ReviewController {
 
 		this.processSettings = processSettings;
 		processReviewUI.setInput(processSettings);
-		//
+
 		if(processSettings != null) {
 			List<ReviewSetting> reviewSettings = processSettings.getReviewSettings();
 			if(!reviewSettings.isEmpty()) {
@@ -135,7 +135,7 @@ public class ReviewController {
 		} else {
 			extendedComparisonUI.update(null, null);
 		}
-		//
+
 		extendedPeakTracesUI.update(peak);
 	}
 
@@ -153,13 +153,13 @@ public class ReviewController {
 				 */
 				int startRetentionTime = getStartRetentionTime();
 				int stopRetentionTime = getStopRetentionTime();
-				//
+
 				if(isRetentionTimeRangeValid(startRetentionTime, stopRetentionTime)) {
 					startRetentionTime = (startRetentionTime < chromatogram.getStartRetentionTime()) ? chromatogram.getStartRetentionTime() : startRetentionTime;
 					stopRetentionTime = (stopRetentionTime > chromatogram.getStopRetentionTime()) ? chromatogram.getStopRetentionTime() : stopRetentionTime;
 					PeakType peakType = reviewSetting.getPeakType();
 					boolean optimizeRange = reviewSetting.isOptimizeRange();
-					//
+
 					if(peakType != null) {
 						/*
 						 * The detector range defines how to detect peaks.
@@ -181,7 +181,7 @@ public class ReviewController {
 						chartSettings.setDeltaRetentionTimeRight(PreferenceSupplier.getReviewDeltaRightMilliseconds());
 						chartSettings.setReplacePeak(PreferenceSupplier.isReviewReplaceNearestPeak());
 						chartSettings.setReplacePeakDelta(PreferenceSupplier.getReviewReplacePeakDeltaMilliseconds());
-						//
+
 						peakDetectorChart.update(detectorRange, chartSettings);
 						/*
 						 * Focus XIC
@@ -246,7 +246,7 @@ public class ReviewController {
 					 */
 					Range selectedRangeX = peakDetectorChart.getCurrentRangeX();
 					Range selectedRangeY = peakDetectorChart.getCurrentRangeY();
-					//
+
 					if(PreferenceSupplier.isReviewSetTargetDetectedPeak() && reviewSetting != null) {
 						peak.setDetectorDescription(DETECTOR_DESCRIPTION);
 						ReviewSupport.setReview(peak, reviewSetting, true, true);
@@ -263,7 +263,7 @@ public class ReviewController {
 				}
 			}
 		});
-		//
+
 		peakDetectorChart.setSectionUpdateListener(new ISectionUpdateListener() {
 
 			@Override
@@ -278,7 +278,7 @@ public class ReviewController {
 				processReviewUI.setSelection(index);
 			}
 		});
-		//
+
 		peakDetectorChart.setRangeUpdateListener(new IRangeUpdateListener() {
 
 			@Override
@@ -292,9 +292,9 @@ public class ReviewController {
 					int retentionTimeDelta = zoomIn ? -offset : offset;
 					int startRetentionTime = reviewSetting.getStartRetentionTime() - retentionTimeDelta;
 					int stopRetentionTime = reviewSetting.getStopRetentionTime() + retentionTimeDelta;
-					//
+
 					if(startRetentionTime < stopRetentionTime) {
-						//
+
 						reviewSetting.setStartRetentionTime(startRetentionTime);
 						reviewSetting.setStopRetentionTime(stopRetentionTime);
 						/*
@@ -340,7 +340,7 @@ public class ReviewController {
 	private void updatePeakStatusUI(IPeak peak) {
 
 		List<IPeak> peaks = new ArrayList<>();
-		//
+
 		if(processReviewUI != null && reviewSetting != null && processSettings != null) {
 			IChromatogram chromatogram = processSettings.getChromatogram();
 			if(chromatogram != null) {
@@ -350,7 +350,7 @@ public class ReviewController {
 				int startRetentionTime = getStartRetentionTime();
 				int stopRetentionTime = getStopRetentionTime();
 				List<? extends IChromatogramPeak> chromatogramPeaks = chromatogram.getPeaks(startRetentionTime, stopRetentionTime);
-				//
+
 				if(PreferenceSupplier.isReviewShowOnlyRelevantPeaks() && isChromatogramMSD(chromatogram)) {
 					Set<Integer> traces = peakDetectorListUtil.extractTraces(reviewSetting.getTraces());
 					for(IPeak chromatogramPeak : chromatogramPeaks) {
@@ -363,7 +363,7 @@ public class ReviewController {
 				}
 			}
 		}
-		//
+
 		if(extendedPeakReviewUI != null) {
 			extendedPeakReviewUI.setInput(reviewSetting, peaks, peak);
 		}


### PR DESCRIPTION
This is similar to https://github.com/eclipse-chemclipse/chemclipse/pull/2169 in principle. Say you have

* Substance A Peak 1: CAS 123-456-7
* Substance A Peak 2: CAS 123-456-7
* Substance A Peak 3: CAS 123-456-7

This causes the peak selection in the status table to not move because the fallback after name mismatch is the CAS registry number, and they all share the same one because it is the same substance or rather mixture after all. They are, however, not integrated as a group but rather single peaks because they are so far apart. However, the status line and the chromatogram chart move, which makes the UI inconsistent.

The previous selection were also never cleared. This is a problem when you set delta right/left really wide (100,000 ms) and you want to scroll through multiple peaks in that range.