### PR TITLE
Fix checkbox mark in checkbox not drawn on GTK Adwaita

### DIFF
--- a/openchrom/plugins/net.openchrom.installer.ui/src/net/openchrom/installer/ui/wizards/PluginDiscoveryWizardMainPage.java
+++ b/openchrom/plugins/net.openchrom.installer.ui/src/net/openchrom/installer/ui/wizards/PluginDiscoveryWizardMainPage.java
@@ -622,7 +622,6 @@ public class PluginDiscoveryWizardMainPage extends WizardPage {
 			checkbox.setText(" "); //$NON-NLS-1$
 			// help UI tests
 			checkbox.setData("pluginId", plugin.getInstallableUnits()); //$NON-NLS-1$
-			configureLook(checkbox, background);
 			checkbox.setSelection(installableConnectors.contains(plugin));
 			checkbox.addFocusListener(new FocusAdapter() {
 


### PR DESCRIPTION
Setting background without foreground opens the possibility that the 2 colors will match making the check practically invisible.