### PR TITLE
Fix SWT Resources disposal runtime warnings in installer

### DIFF
--- a/openchrom/plugins/net.openchrom.installer.ui/src/net/openchrom/installer/ui/wizards/PluginDiscoveryWizardMainPage.java
+++ b/openchrom/plugins/net.openchrom.installer.ui/src/net/openchrom/installer/ui/wizards/PluginDiscoveryWizardMainPage.java
@@ -286,9 +286,6 @@ public class PluginDiscoveryWizardMainPage extends WizardPage {
 	public void dispose() {
 
 		super.dispose();
-		for(Resource resource : disposables) {
-			resource.dispose();
-		}
 		clearDisposables();
 		if(discovery != null) {
 			discovery.dispose();
@@ -296,7 +293,9 @@ public class PluginDiscoveryWizardMainPage extends WizardPage {
 	}
 
 	private void clearDisposables() {
-
+		for(Resource resource : disposables) {
+			resource.dispose();
+		}
 		disposables.clear();
 		h1Font = null;
 		h2Font = null;


### PR DESCRIPTION
Method createBodyContent calls clearDisposable which empties the disposables collections without actually disposing them leading to dangling references.
Make the method actually dispose all disposables before clearing ensures that all resources are actually freed.