### PR TITLE
Remove runtime requirement on org.osgi.service.component.annotations

### DIFF
--- a/openchrom/plugins/net.openchrom.chromatogram.msd.peak.detector.supplier.amdis/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.chromatogram.msd.peak.detector.supplier.amdis/META-INF/MANIFEST.MF
@@ -27,7 +27,6 @@ Export-Package: net.openchrom.chromatogram.msd.peak.detector.supplier.amdis.core
  net.openchrom.chromatogram.msd.peak.detector.supplier.amdis.preferences,
  net.openchrom.chromatogram.msd.peak.detector.supplier.amdis.settings,
  net.openchrom.chromatogram.msd.peak.detector.supplier.amdis.support
-Import-Package: org.eclipse.chemclipse.xxd.filter.peaks,
- org.osgi.service.component.annotations;version="1.2.0"
+Import-Package: org.eclipse.chemclipse.xxd.filter.peaks
 Service-Component: OSGI-INF/net.openchrom.chromatogram.msd.peak.detector.supplier.amdis.filter.AmbiguousPeakRemoverFilter.xml
 Bundle-Localization: OSGI-INF/l10n/bundle

--- a/openchrom/plugins/net.openchrom.chromatogram.xxd.identifier.supplier.jmol.ui/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.chromatogram.xxd.identifier.supplier.jmol.ui/META-INF/MANIFEST.MF
@@ -15,6 +15,5 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.chemclipse.support.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
-Import-Package: org.osgi.service.event;version="1.3.0",
- org.osgi.service.component.annotations;version="[1.2.0,2.0.0)"
+Import-Package: org.osgi.service.event;version="1.3.0"
 Service-Component: OSGI-INF/net.openchrom.chromatogram.xxd.identifier.supplier.jmol.ui.services.MoleculeImageService.xml

--- a/openchrom/plugins/net.openchrom.chromatogram.xxd.report.supplier.csv.ui/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.chromatogram.xxd.report.supplier.csv.ui/META-INF/MANIFEST.MF
@@ -21,5 +21,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.e4.core.services;bundle-version="2.3.400"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
-Import-Package: org.osgi.service.component.annotations;version="1.3.0"
 Service-Component: OSGI-INF/net.openchrom.chromatogram.xxd.report.supplier.csv.ui.services.ReportColumnsAnnotationService.xml

--- a/openchrom/plugins/net.openchrom.chromatogram.xxd.report.supplier.csv/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.chromatogram.xxd.report.supplier.csv/META-INF/MANIFEST.MF
@@ -27,5 +27,4 @@ Export-Package: net.openchrom.chromatogram.xxd.report.supplier.csv.core,
  net.openchrom.chromatogram.xxd.report.supplier.csv.service,
  net.openchrom.chromatogram.xxd.report.supplier.csv.settings,
  net.openchrom.chromatogram.xxd.report.supplier.csv.validators
-Import-Package: org.osgi.service.component.annotations;version="1.3.0"
 Service-Component: OSGI-INF/net.openchrom.chromatogram.xxd.report.supplier.csv.service.ReportColumnsSerializationService.xml

--- a/openchrom/plugins/net.openchrom.chromatogram.xxd.report.supplier.excel.template.ui/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.chromatogram.xxd.report.supplier.excel.template.ui/META-INF/MANIFEST.MF
@@ -21,4 +21,3 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.logging;bundle-version="0.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
-Import-Package: org.osgi.service.component.annotations;version="1.3.0"

--- a/openchrom/plugins/net.openchrom.chromatogram.xxd.report.supplier.excel.template/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.chromatogram.xxd.report.supplier.excel.template/META-INF/MANIFEST.MF
@@ -25,4 +25,3 @@ Export-Package: net.openchrom.chromatogram.xxd.report.supplier.excel.template.co
  net.openchrom.chromatogram.xxd.report.supplier.excel.template.io,
  net.openchrom.chromatogram.xxd.report.supplier.excel.template.preferences,
  net.openchrom.chromatogram.xxd.report.supplier.excel.template.settings
-Import-Package: org.osgi.service.component.annotations;version="1.3.0"

--- a/openchrom/plugins/net.openchrom.installer/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.installer/META-INF/MANIFEST.MF
@@ -17,7 +17,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.rcp.ui.icons;bundle-version="0.8.0",
  org.eclipse.chemclipse.logging;bundle-version="0.8.0",
  org.eclipse.chemclipse.support;bundle-version="0.9.0"
-Import-Package: org.osgi.service.component.annotations;version="1.2.0"
 Export-Package: net.openchrom.installer,
  net.openchrom.installer.model,
  net.openchrom.installer.preferences,

--- a/openchrom/plugins/net.openchrom.xxd.classifier.supplier.ratios/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.xxd.classifier.supplier.ratios/META-INF/MANIFEST.MF
@@ -22,7 +22,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.chemclipse.wsd.model;bundle-version="0.8.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
-Import-Package: org.osgi.service.component.annotations;version="1.2.0"
 Export-Package: net.openchrom.xxd.classifier.supplier.ratios,
  net.openchrom.xxd.classifier.supplier.ratios.compiler,
  net.openchrom.xxd.classifier.supplier.ratios.core,

--- a/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/META-INF/MANIFEST.MF
@@ -34,6 +34,5 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Import-Package: jakarta.inject;version="2.0.1",
- org.osgi.service.component.annotations;version="[1.2.0,2.0.0)",
  org.osgi.service.event;version="1.3.0"
 Service-Component: OSGI-INF/net.openchrom.xxd.identifier.supplier.cdk.ui.services.MoleculeImageService.xml

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/META-INF/MANIFEST.MF
@@ -61,7 +61,6 @@ Import-Package: jakarta.annotation;version="2.1.1",
  jakarta.xml.bind,
  jakarta.xml.bind.annotation,
  jakarta.xml.bind.annotation.adapters,
- org.osgi.service.component.annotations;version="[1.2.0,2.0.0)",
  org.osgi.service.event;version="[1.0.0,2.0.0)"
 Export-Package: net.openchrom.xxd.process.supplier.templates.ui.charts,
  net.openchrom.xxd.process.supplier.templates.ui.core,

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/META-INF/MANIFEST.MF
@@ -47,7 +47,6 @@ Export-Package: net.openchrom.xxd.process.supplier.templates,
  net.openchrom.xxd.process.supplier.templates.support,
  net.openchrom.xxd.process.supplier.templates.system,
  net.openchrom.xxd.process.supplier.templates.util
-Import-Package: org.osgi.service.component.annotations;version="1.2.0"
 Service-Component: OSGI-INF/net.openchrom.xxd.process.supplier.templates.service.ReportColumnsSerializationService.xml,
  OSGI-INF/net.openchrom.xxd.process.supplier.templates.service.ReportSettingsSerializationService.xml,
  OSGI-INF/net.openchrom.xxd.process.supplier.templates.system.DetectorExportProcessSupplier.xml,


### PR DESCRIPTION
These are needed only at build time for DS xml files generation and both Tycho and PDE will handle setting it up proper without needless explicit runtime dependency.