### PR TITLE
Stop building source bundles

### DIFF
--- a/openchrom/pom.xml
+++ b/openchrom/pom.xml
@@ -81,19 +81,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>${tycho.groupid}</groupId>
-				<artifactId>tycho-source-plugin</artifactId>
-				<version>${tycho.version}</version>
-				<executions>
-					<execution>
-						<id>plugin-source</id>
-						<goals>
-							<goal>plugin-source</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-compiler-plugin</artifactId>
 				<version>${tycho.version}</version>


### PR DESCRIPTION
They are not used at all anywhere so it's just time lost during compile.