### PR TITLE
Fix crashes when saving AnIML when file is not set

### DIFF
--- a/openchrom/plugins/net.openchrom.csd.converter.supplier.animl/src/net/openchrom/csd/converter/supplier/animl/io/ChromatogramWriter.java
+++ b/openchrom/plugins/net.openchrom.csd.converter.supplier.animl/src/net/openchrom/csd/converter/supplier/animl/io/ChromatogramWriter.java
@@ -88,7 +88,10 @@ public class ChromatogramWriter extends AbstractChromatogramCSDWriter {
 		sample.setName(chromatogram.getSampleName());
 		sample.setBarcode(chromatogram.getBarcode());
 		sample.setComment(chromatogram.getMiscInfo());
-		sample.setSampleID(FilenameUtils.removeExtension(chromatogram.getFile().getName()));
+		File file = chromatogram.getFile();
+		if(file != null) {
+			sample.setSampleID(FilenameUtils.removeExtension(file.getName()));
+		}
 		sampleSet.getSample().add(sample);
 		return sampleSet;
 	}

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/io/ChromatogramWriter.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.animl/src/net/openchrom/msd/converter/supplier/animl/io/ChromatogramWriter.java
@@ -97,7 +97,10 @@ public class ChromatogramWriter extends AbstractChromatogramMSDWriter {
 		sample.setName(chromatogram.getSampleName());
 		sample.setBarcode(chromatogram.getBarcode());
 		sample.setComment(chromatogram.getMiscInfo());
-		sample.setSampleID(FilenameUtils.removeExtension(chromatogram.getFile().getName()));
+		File file = chromatogram.getFile();
+		if(file != null) {
+			sample.setSampleID(FilenameUtils.removeExtension(file.getName()));
+		}
 		sampleSet.getSample().add(sample);
 		return sampleSet;
 	}

--- a/openchrom/plugins/net.openchrom.wsd.converter.supplier.animl/src/net/openchrom/wsd/converter/supplier/animl/io/ChromatogramWriter.java
+++ b/openchrom/plugins/net.openchrom.wsd.converter.supplier.animl/src/net/openchrom/wsd/converter/supplier/animl/io/ChromatogramWriter.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 
+import org.apache.commons.io.FilenameUtils;
 import org.eclipse.chemclipse.converter.exceptions.FileIsNotWriteableException;
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.chemclipse.model.core.IScan;
@@ -94,7 +95,10 @@ public class ChromatogramWriter extends AbstractChromatogramWSDWriter {
 		sample.setName(chromatogram.getSampleName());
 		sample.setBarcode(chromatogram.getBarcode());
 		sample.setComment(chromatogram.getMiscInfo());
-		sample.setSampleID(chromatogram.getSampleName());
+		File file = chromatogram.getFile();
+		if(file != null) {
+			sample.setSampleID(FilenameUtils.removeExtension(file.getName()));
+		}
 		sampleSet.getSample().add(sample);
 		return sampleSet;
 	}


### PR DESCRIPTION
Harden against the same problem as https://github.com/eclipse-chemclipse/chemclipse/issues/2361.