### PR TITLE
Bundle Java runtime via JustJ

### DIFF
--- a/openchrom/pom.xml
+++ b/openchrom/pom.xml
@@ -28,6 +28,15 @@
 		<maven.groupid>org.apache.maven.plugins</maven.groupid>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
+
+	<repositories>
+		<repository>
+			<id>jre-updates</id>
+			<url>https://download.eclipse.org/justj/jres/21/updates/release/latest/</url>
+			<layout>p2</layout>
+		</repository>
+	</repositories>
+
 	<build>
 		<!-- PLUGINS -->
 		<plugins>
@@ -76,6 +85,11 @@
 							<arch>x86_64</arch>
 						</environment>
 					</environments>
+					<dependency-resolution>
+						<profileProperties>
+							<org.eclipse.justj.buildtime>true</org.eclipse.justj.buildtime>
+						</profileProperties>
+					</dependency-resolution>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/openchrom/products/net.openchrom.rcp.compilation.community.product/openchrom.compilation.community.product
+++ b/openchrom/products/net.openchrom.rcp.compilation.community.product/openchrom.compilation.community.product
@@ -68,6 +68,7 @@ Contributors:
 
    <features>
       <feature id="net.openchrom.platform.feature"/>
+      <feature id="org.eclipse.justj.openjdk.hotspot.jre.full" installMode="root"/>
    </features>
 
    <configurations>


### PR DESCRIPTION
This adds back a JRE but this time provided by @eclipse-justj instead of @lablicate.