### PR TITLE
Speed up tests run

### DIFF
--- a/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
+++ b/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
@@ -5,7 +5,8 @@
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<repository location="https://download.eclipse.org/releases/2025-06/"/>
 		<unit id="org.eclipse.equinox.sdk.feature.group"/>
-		<unit id="org.eclipse.sdk.feature.group"/>
+		<unit id="org.eclipse.platform.feature.group"/>
+		<unit id="org.eclipse.jdt.junit5.runtime"/>
 		<unit id="com.google.protobuf"/>
 		<unit id="org.jdom2"/>
 		<unit id="org.apache.aries.spifly.dynamic.bundle"/>
@@ -100,22 +101,6 @@
 				<groupId>dk.brics</groupId>
 				<artifactId>automaton</artifactId>
 				<version>1.12-1</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="org.apache.logging.log4j" missingManifest="generate" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-api</artifactId>
-				<version>2.23.1</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-core</artifactId>
-				<version>2.23.1</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
Reduce target platform to only needed parts as PDE generates uses conflicts with the rest of the things in the target platform.