### PR TITLE
Refresh Windows certificate store by subdomain

### DIFF
--- a/openchrom/plugins/net.openchrom.installer/src/net/openchrom/installer/Activator.java
+++ b/openchrom/plugins/net.openchrom.installer/src/net/openchrom/installer/Activator.java
@@ -55,8 +55,9 @@ public class Activator implements BundleActivator {
 	// Workaround for https://github.com/eclipse-platform/eclipse.platform/issues/1690
 	private void refreshWindowsCertificateStore() throws MalformedURLException, URISyntaxException {
 
-		refreshWindowsCertificateStore(new URI("https://openchrom.net").toURL());
-		refreshWindowsCertificateStore(new URI("https://lablicate.com").toURL());
+		refreshWindowsCertificateStore(new URI("https://converter.openchrom.net").toURL());
+		refreshWindowsCertificateStore(new URI("https://plugins.openchrom.net").toURL());
+		refreshWindowsCertificateStore(new URI("https://marketplace.lablicate.com").toURL());
 	}
 
 	private void refreshWindowsCertificateStore(URL url) {


### PR DESCRIPTION
I thought SSL worked per domain, but I guess I was wrong, as https://github.com/OpenChrom/openchrom/pull/692 does not work.