### PR TITLE
Fixed missing hydrogens and added an option to disable atom coloring

### DIFF
--- a/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/src/net/openchrom/xxd/identifier/supplier/cdk/ui/converter/AWTMolDrawer.java
+++ b/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/src/net/openchrom/xxd/identifier/supplier/cdk/ui/converter/AWTMolDrawer.java
@@ -47,7 +47,7 @@ public class AWTMolDrawer {
 		try {
 			ImageIO.write((RenderedImage)image, "PNG", new File(imageFile));
 		} catch(IOException e) {
-			logger.warn("Some IO Error occured while instantiating AWTMolDrawer object. Here is more information:\n" + e);
+			logger.warn("Some IO Error occured while instantiating AWTMolDrawer object." + e);
 		}
 	}
 }

--- a/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/src/net/openchrom/xxd/identifier/supplier/cdk/ui/converter/AwtToSwtImageBridge.java
+++ b/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/src/net/openchrom/xxd/identifier/supplier/cdk/ui/converter/AwtToSwtImageBridge.java
@@ -19,10 +19,12 @@ package net.openchrom.xxd.identifier.supplier.cdk.ui.converter;
  */
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
+import java.awt.image.ComponentColorModel;
 import java.awt.image.DirectColorModel;
 import java.awt.image.IndexColorModel;
 import java.awt.image.WritableRaster;
 
+import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
@@ -33,6 +35,8 @@ import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Display;
 
 public class AwtToSwtImageBridge {
+
+	private static final Logger logger = Logger.getLogger(AwtToSwtImageBridge.class);
 
 	static BufferedImage convertToAWT(ImageData data) {
 
@@ -119,6 +123,38 @@ public class AwtToSwtImageBridge {
 				}
 			}
 			return data;
+		} else if(bufferedImage.getColorModel() instanceof ComponentColorModel componentColorModel) {
+			int width = bufferedImage.getWidth();
+			int height = bufferedImage.getHeight();
+			int pixelSize = componentColorModel.getPixelSize();
+			boolean hasAlpha = componentColorModel.hasAlpha();
+
+			// Fallback to ARGB masks, assuming 8 bits per component
+			PaletteData palette = new PaletteData(0x00FF0000, 0x0000FF00, 0x000000FF);
+			ImageData data = new ImageData(width, height, pixelSize, palette);
+
+			WritableRaster raster = bufferedImage.getRaster();
+			int[] pixelComponents = new int[componentColorModel.getNumComponents()];
+
+			for(int y = 0; y < height; y++) {
+				for(int x = 0; x < width; x++) {
+					raster.getPixel(x, y, pixelComponents);
+
+					int r = pixelComponents[0];
+					int g = pixelComponents[1];
+					int b = pixelComponents[2];
+					int a = hasAlpha ? pixelComponents[3] : 0xFF;
+
+					int pixel = palette.getPixel(new RGB(r, g, b));
+					data.setPixel(x, y, pixel);
+					if(hasAlpha) {
+						data.setAlpha(x, y, a);
+					}
+				}
+			}
+			return data;
+		} else {
+			logger.warn("Unsupported color model.");
 		}
 		return null;
 	}

--- a/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/src/net/openchrom/xxd/identifier/supplier/cdk/ui/converter/ImageConverter.java
+++ b/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/src/net/openchrom/xxd/identifier/supplier/cdk/ui/converter/ImageConverter.java
@@ -14,26 +14,16 @@
 package net.openchrom.xxd.identifier.supplier.cdk.ui.converter;
 
 import java.awt.Color;
-import java.awt.Graphics2D;
 import java.awt.Image;
-import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.eclipse.chemclipse.logging.core.Logger;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Display;
+import org.openscience.cdk.depict.DepictionGenerator;
+import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.layout.StructureDiagramGenerator;
-import org.openscience.cdk.renderer.AtomContainerRenderer;
-import org.openscience.cdk.renderer.IRenderer;
-import org.openscience.cdk.renderer.font.AWTFontManager;
-import org.openscience.cdk.renderer.generators.BasicAtomGenerator;
-import org.openscience.cdk.renderer.generators.BasicBondGenerator;
 import org.openscience.cdk.renderer.generators.BasicSceneGenerator;
-import org.openscience.cdk.renderer.generators.IGenerator;
-import org.openscience.cdk.renderer.visitor.AWTDrawVisitor;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
 import net.openchrom.xxd.identifier.supplier.cdk.converter.CDKSmilesToMoleculeConverter;
@@ -65,7 +55,7 @@ public class ImageConverter {
 		return createImage(molecule, width, height);
 	}
 
-	public Image moleculeToImage(IAtomContainer molecule, int width, int height) {
+	public BufferedImage moleculeToImage(IAtomContainer molecule, int width, int height) {
 
 		return createImage(molecule, width, height);
 	}
@@ -74,10 +64,12 @@ public class ImageConverter {
 
 		IAtomContainer molecule = structureConverter.generate(converterInput);
 		if(molecule != null) {
-			return new org.eclipse.swt.graphics.Image(display, AwtToSwtImageBridge.convertToSWT((BufferedImage)moleculeToImage(molecule, point.x, point.y)));
-		} else {
-			return null;
+			BufferedImage image = moleculeToImage(molecule, point.x, point.y);
+			if(image != null) {
+				return new org.eclipse.swt.graphics.Image(display, AwtToSwtImageBridge.convertToSWT(image));
+			}
 		}
+		return null;
 	}
 
 	/**
@@ -88,51 +80,30 @@ public class ImageConverter {
 	 * @param height
 	 * @return Image
 	 */
-	private Image createImage(IAtomContainer molecule, int width, int height) {
+	private BufferedImage createImage(IAtomContainer molecule, int width, int height) {
 
-		Image image = null;
-		if(molecule != null) {
-			/*
-			 * Only create the image if the molecule is not null.
-			 */
-			image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-			Rectangle drawArea = new Rectangle(width, height);
-
-			if(PreferenceSupplier.isShowAtomsH()) {
-				AtomContainerManipulator.convertImplicitToExplicitHydrogens(molecule);
-			}
-
-			StructureDiagramGenerator structureDiagramGenerator = new StructureDiagramGenerator();
-			structureDiagramGenerator.setMolecule(molecule);
-			try {
-				structureDiagramGenerator.generateCoordinates();
-			} catch(Exception e) {
-				/*
-				 * It's not possible to parse the molecule => well-formed smiles?
-				 */
-				logger.warn("CANNOT INSTANTIATE COORDINATES: " + e);
-				return null;
-			}
-			/*
-			 * Use another name for the diagram molecule. Otherwise it's a bit confusing.
-			 */
-			IAtomContainer diagramMolecule = structureDiagramGenerator.getMolecule();
-			// Generators make the image elements
-			List<IGenerator<IAtomContainer>> generators = new ArrayList<>();
-			generators.add(new BasicSceneGenerator());
-			generators.add(new BasicBondGenerator());
-			generators.add(new BasicAtomGenerator());
-
-			IRenderer<IAtomContainer> renderer = new AtomContainerRenderer(generators, new AWTFontManager());
-			renderer.setup(diagramMolecule, drawArea);
-			// Paint the background
-			Graphics2D g2 = (Graphics2D)image.getGraphics();
-			g2.setColor(Color.WHITE);
-			g2.fillRect(0, 0, width, height);
-			// The paint method also needs a toolkit-specific renderer
-			renderer.paint(diagramMolecule, new AWTDrawVisitor(g2));
+		/*
+		 * Only create the image if the molecule is not null.
+		 */
+		if(molecule == null) {
+			return null;
 		}
 
-		return image;
+		if(PreferenceSupplier.isShowAtomsH()) {
+			AtomContainerManipulator.convertImplicitToExplicitHydrogens(molecule);
+		}
+
+		DepictionGenerator depictionGenerator = new DepictionGenerator() //
+				.withSize(width, height) //
+				.withMargin(0.1) //
+				.withZoom(2.0) //
+				.withParam(BasicSceneGenerator.BackgroundColor.class, Color.white);
+
+		try {
+			return depictionGenerator.depict(molecule).toImg();
+		} catch(CDKException e) {
+			logger.error(e);
+		}
+		return null;
 	}
 }

--- a/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/src/net/openchrom/xxd/identifier/supplier/cdk/ui/converter/ImageConverter.java
+++ b/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/src/net/openchrom/xxd/identifier/supplier/cdk/ui/converter/ImageConverter.java
@@ -99,6 +99,10 @@ public class ImageConverter {
 				.withZoom(2.0) //
 				.withParam(BasicSceneGenerator.BackgroundColor.class, Color.white);
 
+		if(PreferenceSupplier.isColorAtoms()) {
+			depictionGenerator = depictionGenerator.withAtomColors();
+		}
+
 		try {
 			return depictionGenerator.depict(molecule).toImg();
 		} catch(CDKException e) {

--- a/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/src/net/openchrom/xxd/identifier/supplier/cdk/ui/preferences/PreferencePage.java
+++ b/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/src/net/openchrom/xxd/identifier/supplier/cdk/ui/preferences/PreferencePage.java
@@ -39,6 +39,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	 * GUI blocks needed to manipulate various types of preferences. Each field
 	 * editor knows how to save and restore itself.
 	 */
+	@Override
 	public void createFieldEditors() {
 
 		addField(new RadioGroupFieldEditor(PreferenceSupplier.P_ISOTOPE_SET, "Select an isotope set.", 1, PreferenceSupplier.getIsotopePreferenceOptions(), getFieldEditorParent()));
@@ -61,6 +62,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceSupplier.P_SHOW_ATOMS_H, "Show H Atoms", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceSupplier.P_ATOMS_COLORS, "Color Atoms", getFieldEditorParent()));
 	}
 
 	/*
@@ -68,6 +70,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	 * @see
 	 * org.eclipse.ui.IWorkbenchPreferencePage#init(org.eclipse.ui.IWorkbench)
 	 */
+	@Override
 	public void init(IWorkbench workbench) {
 
 	}

--- a/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/src/net/openchrom/xxd/identifier/supplier/cdk/ui/services/MoleculeImageService.java
+++ b/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/src/net/openchrom/xxd/identifier/supplier/cdk/ui/services/MoleculeImageService.java
@@ -125,12 +125,8 @@ public class MoleculeImageService implements IMoleculeImageService {
 	private Image convertMoleculeToImage(Display display, IStructureConverter structureConverter, String converterInput, int width, int height) {
 
 		Image image = null;
-		try {
-			Point point = calculateMoleculeImageSize(width, height);
-			image = ImageConverter.getInstance().moleculeToImage(display, structureConverter, converterInput, point);
-		} catch(Exception e) {
-			logger.warn(e);
-		}
+		Point point = calculateMoleculeImageSize(width, height);
+		image = ImageConverter.getInstance().moleculeToImage(display, structureConverter, converterInput, point);
 		return image;
 	}
 

--- a/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk/src/net/openchrom/xxd/identifier/supplier/cdk/preferences/PreferenceSupplier.java
+++ b/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk/src/net/openchrom/xxd/identifier/supplier/cdk/preferences/PreferenceSupplier.java
@@ -65,6 +65,9 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static final String P_SHOW_ATOMS_H = "showAtomsH";
 	public static final boolean DEF_SHOW_ATOMS_H = false;
 
+	public static final String P_ATOMS_COLORS = "atomColors";
+	public static final boolean DEF_ATOMS_COLORS = true;
+
 	public static IPreferenceSupplier INSTANCE() {
 
 		return INSTANCE(PreferenceSupplier.class);
@@ -95,6 +98,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 		putDefault(P_DELETE_PEAK_TARGETS, Boolean.toString(DEF_DELETE_PEAK_TARGETS));
 
 		putDefault(P_SHOW_ATOMS_H, Boolean.toString(DEF_SHOW_ATOMS_H));
+		putDefault(P_ATOMS_COLORS, Boolean.toString(DEF_ATOMS_COLORS));
 	}
 
 	public static IsotopeDecider getIsotopeDecider() {
@@ -192,5 +196,10 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	public static boolean isShowAtomsH() {
 
 		return INSTANCE().getBoolean(P_SHOW_ATOMS_H, DEF_SHOW_ATOMS_H);
+	}
+
+	public static boolean isColorAtoms() {
+
+		return INSTANCE().getBoolean(P_ATOMS_COLORS, DEF_ATOMS_COLORS);
 	}
 }


### PR DESCRIPTION
In https://www.linkedin.com/feed/update/urn:li:activity:7368606106132045824/?actorCompanyId=72945288 @johnmay noticed that we are missing a hydrogen when compared to ChemSketch, which is quite irritating. @egonw suggested using the new https://cdk.github.io/cdkbook/depiction API, which is easier to use and comes with better defaults. I also added an option for not coloring atoms while I was at it.