### PR TITLE
Port to JUnit 5

### DIFF
--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/AAA250PM_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/AAA250PM_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class AAA250PM_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.AAA250PM));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/ACID_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/ACID_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class ACID_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.ACID));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/CAL_3_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/CAL_3_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class CAL_3_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.CAL_3));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/CLASS10_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/CLASS10_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class CLASS10_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.CLASS10));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/CLASSVP_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/CLASSVP_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class CLASSVP_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.CLASSVP));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/DIONEX_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/DIONEX_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class DIONEX_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.DIONEX));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/DNX_7AN_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/DNX_7AN_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class DNX_7AN_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.DNX_7AN));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/EXAMPLE1_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/EXAMPLE1_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class EXAMPLE1_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.EXAMPLE1));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/EXAMPLE_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/EXAMPLE_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class EXAMPLE_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.EXAMPLE));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/HP_CH_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/HP_CH_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class HP_CH_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.HP_CH));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/ICI_21_2_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/ICI_21_2_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class ICI_21_2_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.ICI_21_2));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/PCB_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/PCB_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class PCB_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.PCB));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/PK_SUM01N01_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/PK_SUM01N01_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class PK_SUM01N01_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.PK_SUM01N01));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/SHIMADZU_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/SHIMADZU_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class SHIMADZU_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.SHIMADZU));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/SHMDZU1_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/SHMDZU1_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class SHMDZU1_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.SHMDZU1));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/SOLV001_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/SOLV001_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class SOLV001_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.SOLV001));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/SPA_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/SPA_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class SPA_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.SPA));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/STEROIDS_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/STEROIDS_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class STEROIDS_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.STEROIDS));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/TGNTHPGC_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/TGNTHPGC_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TGNTHPGC_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TGNTHPGC));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/TGNTHPLAS_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/TGNTHPLAS_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TGNTHPLAS_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TGNTHPLAS));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/TGNTPE41_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/TGNTPE41_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TGNTPE41_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TGNTPE41));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/TestPathHelper.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/TestPathHelper.java
@@ -12,6 +12,10 @@
  *******************************************************************************/
 package net.openchrom.csd.converter.supplier.cdf;
 
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
 public class TestPathHelper extends PathResolver {
 
 	public static final String DIONEX = "testData/Dionex/DIONEX.CDF";

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/VARIAN1_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/VARIAN1_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class VARIAN1_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.VARIAN1));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/VARIAN2_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/VARIAN2_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class VARIAN2_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.VARIAN2));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/VARIAN3_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/VARIAN3_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class VARIAN3_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.VARIAN3));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/VARIAN4_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/VARIAN4_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class VARIAN4_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.VARIAN4));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/WATERS4_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/WATERS4_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class WATERS4_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.WATERS4));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/WAT_490_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/WAT_490_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class WAT_490_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.WAT_490));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/WAT_9962_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/WAT_9962_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class WAT_9962_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.WAT_9962));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/WAT_MS2D_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.cdf.fragment.test/src/net/openchrom/csd/converter/supplier/cdf/WAT_MS2D_ITest.java
@@ -22,15 +22,18 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.cdf.converter.ChromatogramImportConverterCSD;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class WAT_MS2D_ITest {
 
-	private static IChromatogramCSD chromatogram;
+	private IChromatogramCSD chromatogram;
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.WAT_MS2D));
 		ChromatogramImportConverterCSD importConverter = new ChromatogramImportConverterCSD();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.gaml.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.gaml.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.csd.converter.supplier.gaml.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.csd.converter.supplier.gaml;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.gaml.fragment.test/src/net/openchrom/csd/converter/supplier/gaml/fragment/test/Multichrom_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.gaml.fragment.test/src/net/openchrom/csd/converter/supplier/gaml/fragment/test/Multichrom_ITest.java
@@ -12,26 +12,29 @@
  *******************************************************************************/
 package net.openchrom.csd.converter.supplier.gaml.fragment.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.gaml.PathResolver;
 import net.openchrom.csd.converter.supplier.gaml.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class Multichrom_ITest {
 
 	private IChromatogramCSD chromatogram;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.MULTICHROM));
 		ChromatogramImportConverter importConverter = new ChromatogramImportConverter();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.gaml.fragment.test/src/net/openchrom/csd/converter/supplier/gaml/fragment/test/TurbochromGC_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.gaml.fragment.test/src/net/openchrom/csd/converter/supplier/gaml/fragment/test/TurbochromGC_ITest.java
@@ -12,26 +12,29 @@
  *******************************************************************************/
 package net.openchrom.csd.converter.supplier.gaml.fragment.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.gaml.PathResolver;
 import net.openchrom.csd.converter.supplier.gaml.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TurbochromGC_ITest {
 
 	private IChromatogramCSD chromatogram;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TURBOCHROM_GC));
 		ChromatogramImportConverter importConverter = new ChromatogramImportConverter();

--- a/openchrom/tests/net.openchrom.csd.converter.supplier.gaml.fragment.test/src/net/openchrom/csd/converter/supplier/gaml/fragment/test/TurbochromLC_ITest.java
+++ b/openchrom/tests/net.openchrom.csd.converter.supplier.gaml.fragment.test/src/net/openchrom/csd/converter/supplier/gaml/fragment/test/TurbochromLC_ITest.java
@@ -12,25 +12,28 @@
  *******************************************************************************/
 package net.openchrom.csd.converter.supplier.gaml.fragment.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.csd.model.core.IChromatogramCSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.csd.converter.supplier.gaml.PathResolver;
 import net.openchrom.csd.converter.supplier.gaml.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TurbochromLC_ITest {
 
 	private IChromatogramCSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TURBOCHROM_LC));

--- a/openchrom/tests/net.openchrom.fsd.converter.supplier.gaml.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.fsd.converter.supplier.gaml.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.fsd.converter.supplier.gaml.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.fsd.converter.supplier.gaml;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/openchrom/tests/net.openchrom.fsd.converter.supplier.gaml.fragment.test/src/net/openchrom/fsd/converter/supplier/gaml/fragment/test/TS_AB2_FLSCAN_ITest.java
+++ b/openchrom/tests/net.openchrom.fsd.converter.supplier.gaml.fragment.test/src/net/openchrom/fsd/converter/supplier/gaml/fragment/test/TS_AB2_FLSCAN_ITest.java
@@ -12,26 +12,29 @@
  *******************************************************************************/
 package net.openchrom.fsd.converter.supplier.gaml.fragment.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.fsd.model.core.ISpectrumFSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.fsd.converter.supplier.gaml.PathResolver;
 import net.openchrom.fsd.converter.supplier.gaml.converter.ScanImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TS_AB2_FLSCAN_ITest {
 
 	private ISpectrumFSD spectrumFSD;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TS_AB2_FLSCAN_HELIOS));
 		ScanImportConverter importConverter = new ScanImportConverter();

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.animl.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.animl.fragment.test/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-SymbolicName: net.openchrom.msd.converter.supplier.animl.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.msd.converter.supplier.animl;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0",
- org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"
+Require-Bundle: org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.animl.fragment.test/src/net/openchrom/msd/converter/supplier/animl/converter/ChromatogramImportExport_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.animl.fragment.test/src/net/openchrom/msd/converter/supplier/animl/converter/ChromatogramImportExport_ITest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.animl.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
@@ -24,18 +24,21 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.IProcessingMessage;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.animl.TestPathHelper;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportExport_ITest {
 
 	private static IChromatogramMSD chromatogram;
 	private static File fileExport;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 
 		/*
@@ -78,7 +81,7 @@ public class ChromatogramImportExport_ITest {
 		}
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDown() {
 
 		fileExport.delete();

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.animl.fragment.test/src/net/openchrom/msd/converter/supplier/animl/converter/StrictImport_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.animl.fragment.test/src/net/openchrom/msd/converter/supplier/animl/converter/StrictImport_ITest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.animl.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.util.Calendar;
@@ -23,18 +23,21 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.support.history.IEditInformation;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.animl.PathResolver;
 import net.openchrom.msd.converter.supplier.animl.TestPathHelper;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class StrictImport_ITest {
 
-	private static IChromatogramMSD chromatogram;
+	private IChromatogramMSD chromatogram;
 
-	@BeforeClass
-	public static void setUp() {
+	@BeforeAll
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_MS_STRICT));
 		ChromatogramImportConverter importConverter = new ChromatogramImportConverter();

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.btmsp.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.btmsp.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.msd.converter.supplier.btmsp.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.msd.converter.supplier.btmsp;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="[5.12.0,6.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.btmsp.fragment.test/src/net/openchrom/msd/converter/supplier/btmsp/converter/MassSpectrumImportConverter_Cattle_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.btmsp.fragment.test/src/net/openchrom/msd/converter/supplier/btmsp/converter/MassSpectrumImportConverter_Cattle_ITest.java
@@ -14,9 +14,9 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.btmsp.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
@@ -24,18 +24,21 @@ import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.btmsp.TestPathHelper;
 import net.openchrom.msd.converter.supplier.btmsp.converter.model.IMainSpectraProjection;
 import net.openchrom.msd.converter.supplier.btmsp.converter.model.MainSpectraProjection;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumImportConverter_Cattle_ITest {
 
 	private IMassSpectra massSpectra;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_CATTLE));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: CDF (MSD) Tests
 Bundle-SymbolicName: net.openchrom.msd.converter.supplier.cdf.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Fragment-Host: net.openchrom.msd.converter.supplier.cdf;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.13.2",
- org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"
+Require-Bundle: org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"
 Bundle-Vendor: OpenChrom

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/ChromatogramImportExport_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/ChromatogramImportExport_ITest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -25,18 +25,21 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.processing.core.IProcessingMessage;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportExport_ITest {
 
-	private static IChromatogramMSD chromatogram;
-	private static IChromatogramMSD chromatogramImport;
-	private static File fileExport;
+	private IChromatogramMSD chromatogram;
+	private IChromatogramMSD chromatogramImport;
+	private File fileExport;
 
-	@BeforeClass
-	public static void setUp() {
+	@BeforeAll
+	public void setUp() {
 
 		/*
 		 * Import
@@ -78,8 +81,8 @@ public class ChromatogramImportExport_ITest {
 		}
 	}
 
-	@AfterClass
-	public static void tearDown() {
+	@AfterAll
+	public void tearDown() {
 
 		fileExport.delete();
 	}

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/EXTREL_CENTSCNH_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/EXTREL_CENTSCNH_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class EXTREL_CENTSCNH_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.EXTREL_CENTSCNH));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/EXTREL_CENTSCNL_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/EXTREL_CENTSCNL_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class EXTREL_CENTSCNL_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.EXTREL_CENTSCNL));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/EXTREL_CENTSIDH_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/EXTREL_CENTSIDH_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class EXTREL_CENTSIDH_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.EXTREL_CENTSIDH));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/EXTREL_CENTSIDL_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/EXTREL_CENTSIDL_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class EXTREL_CENTSIDL_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.EXTREL_CENTSIDL));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/EXTREL_CONTINUM_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/EXTREL_CONTINUM_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class EXTREL_CONTINUM_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.EXTREL_CONTINUM));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/FINNIGAN_CENTSCNH_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/FINNIGAN_CENTSCNH_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class FINNIGAN_CENTSCNH_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.FINNIGAN_CENTSCNH));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/FINNIGAN_CENTSCNL_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/FINNIGAN_CENTSCNL_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class FINNIGAN_CENTSCNL_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.FINNIGAN_CENTSCNL));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/FINNIGAN_CONTINUM_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/FINNIGAN_CONTINUM_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class FINNIGAN_CONTINUM_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.FINNIGAN_CONTINUM));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/FISONS_A_CENTSCNH_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/FISONS_A_CENTSCNH_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class FISONS_A_CENTSCNH_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.FISONS_A_CENTSCNH));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/FISONS_A_CENTSCNL_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/FISONS_A_CENTSCNL_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class FISONS_A_CENTSCNL_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.FISONS_A_CENTSCNL));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/FISONS_A_CENTSIDH_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/FISONS_A_CENTSIDH_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class FISONS_A_CENTSIDH_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.FISONS_A_CENTSIDH));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/FISONS_A_CONTINUM_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/FISONS_A_CONTINUM_ITest.java
@@ -12,25 +12,25 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
-@Ignore("NotEnoughScanDataStored") // TODO
+@Disabled("NotEnoughScanDataStored") // TODO
 public class FISONS_A_CONTINUM_ITest {
 
 	private static IChromatogramMSD chromatogram;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.FISONS_A_CONTINUM));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/HP_CENTSCNH_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/HP_CENTSCNH_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class HP_CENTSCNH_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.HP_CENTSCNH));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/HP_CENTSIDH_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/HP_CENTSIDH_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class HP_CENTSIDH_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.HP_CENTSIDH));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/KRATOS_CENTSCNH_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/KRATOS_CENTSCNH_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class KRATOS_CENTSCNH_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.KRATOS_CENTSCNH));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/KRATOS_CENTSCNL_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/KRATOS_CENTSCNL_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class KRATOS_CENTSCNL_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.KRATOS_CENTSCNL));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/PE_SCIEX_CENTSCNH_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/PE_SCIEX_CENTSCNH_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class PE_SCIEX_CENTSCNH_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.PE_SCIEX_CENTSCNH));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/PE_SCIEX_CENTSCNL_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/PE_SCIEX_CENTSCNL_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class PE_SCIEX_CENTSCNL_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.PE_SCIEX_CENTSCNL));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/PE_SCIEX_CENTSIDH_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/PE_SCIEX_CENTSIDH_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class PE_SCIEX_CENTSIDH_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.PE_SCIEX_CENTSIDH));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/PE_SCIEX_CENTSIDL_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/PE_SCIEX_CENTSIDL_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class PE_SCIEX_CENTSIDL_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.PE_SCIEX_CENTSIDL));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/PE_SCIEX_CONTINUM_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/PE_SCIEX_CONTINUM_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class PE_SCIEX_CONTINUM_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.PE_SCIEX_CONTINUM));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/QD_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/QD_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class QD_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.QD));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/TEKNIVNT_CENTSCNH_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/TEKNIVNT_CENTSCNH_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TEKNIVNT_CENTSCNH_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TEKNIVNT_CENTSCNH));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/TEKNIVNT_CENTSCNL_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/TEKNIVNT_CENTSCNL_ITest.java
@@ -12,24 +12,27 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TEKNIVNT_CENTSCNL_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TEKNIVNT_CENTSCNL));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/TEKNIVNT_CONTINUM_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/TEKNIVNT_CONTINUM_ITest.java
@@ -12,26 +12,29 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cdf.converter.ChromatogramImportConverter;
 
-@Ignore("Fails to load.") // TODO
+@Disabled("Fails to load.") // TODO
+@TestInstance(Lifecycle.PER_CLASS)
 public class TEKNIVNT_CONTINUM_ITest {
 
-	private static IChromatogramMSD chromatogram;
+	private IChromatogramMSD chromatogram;
 
-	@BeforeClass
-	public static void setUp() {
+	@BeforeAll
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TEKNIVNT_CONTINUM));
 		ChromatogramImportConverter importConverter = new ChromatogramImportConverter();

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/io/support/DateSupport_1_Test.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cdf.fragment.test/src/net/openchrom/msd/converter/supplier/cdf/io/support/DateSupport_1_Test.java
@@ -12,27 +12,30 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cdf.io.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.text.ParseException;
 import java.util.Date;
 import java.util.TimeZone;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class DateSupport_1_Test {
 
 	private TimeZone defaultTimeZone;
 
-	@Before
+	@BeforeAll
 	public void setUp() {
 
 		defaultTimeZone = TimeZone.getDefault();
 	}
 
-	@After
+	@AfterAll
 	public void tearDown() {
 
 		TimeZone.setDefault(defaultTimeZone); // restore
@@ -44,7 +47,7 @@ public class DateSupport_1_Test {
 		// 12 Nov 2008 7:41 ! CET > +0100
 		TimeZone.setDefault(TimeZone.getTimeZone("CET"));
 		Date date = new Date(1226472095160l);
-		assertEquals("12 Nov 08 7:41", "20081112074135+0100", DateSupport.getDate(date));
+		assertEquals("20081112074135+0100", DateSupport.getDate(date), "12 Nov 08 7:41");
 	}
 
 	@Test
@@ -55,7 +58,7 @@ public class DateSupport_1_Test {
 		TimeZone.setDefault(TimeZone.getTimeZone("CET"));
 		Date test = new Date(1137088020000l);
 		Date date = DateSupport.getDate(agilentDate);
-		assertEquals(agilentDate, test, date);
+		assertEquals(test, date, agilentDate);
 	}
 
 	@Test
@@ -66,7 +69,7 @@ public class DateSupport_1_Test {
 		TimeZone.setDefault(TimeZone.getTimeZone("CET"));
 		Date test = new Date(1140275880000l);
 		Date date = DateSupport.getDate(agilentDate);
-		assertEquals(agilentDate, test, date);
+		assertEquals(test, date, agilentDate);
 	}
 
 	@Test
@@ -77,7 +80,7 @@ public class DateSupport_1_Test {
 		TimeZone.setDefault(TimeZone.getTimeZone("CET"));
 		Date test = new Date(1141392360000l);
 		Date date = DateSupport.getDate(agilentDate);
-		assertEquals(agilentDate, test, date);
+		assertEquals(test, date, agilentDate);
 	}
 
 	@Test
@@ -88,7 +91,7 @@ public class DateSupport_1_Test {
 		TimeZone.setDefault(TimeZone.getTimeZone("CEST"));
 		Date test = new Date(1145274000000l);
 		Date date = DateSupport.getDate(agilentDate);
-		assertEquals(agilentDate, test, date);
+		assertEquals(test, date, agilentDate);
 	}
 
 	@Test
@@ -99,7 +102,7 @@ public class DateSupport_1_Test {
 		TimeZone.setDefault(TimeZone.getTimeZone("CEST"));
 		Date test = new Date(1148025420000l);
 		Date date = DateSupport.getDate(agilentDate);
-		assertEquals(agilentDate, test, date);
+		assertEquals(test, date, agilentDate);
 	}
 
 	@Test
@@ -110,7 +113,7 @@ public class DateSupport_1_Test {
 		TimeZone.setDefault(TimeZone.getTimeZone("CEST"));
 		Date test = new Date(1150485060000l);
 		Date date = DateSupport.getDate(agilentDate);
-		assertEquals(agilentDate, test, date);
+		assertEquals(test, date, agilentDate);
 	}
 
 	@Test
@@ -121,7 +124,7 @@ public class DateSupport_1_Test {
 		TimeZone.setDefault(TimeZone.getTimeZone("CEST"));
 		Date test = new Date(1154104980000l);
 		Date date = DateSupport.getDate(agilentDate);
-		assertEquals(agilentDate, test, date);
+		assertEquals(test, date, agilentDate);
 	}
 
 	@Test
@@ -132,7 +135,7 @@ public class DateSupport_1_Test {
 		TimeZone.setDefault(TimeZone.getTimeZone("CEST"));
 		Date test = new Date(1156257300000l);
 		Date date = DateSupport.getDate(agilentDate);
-		assertEquals(agilentDate, test, date);
+		assertEquals(test, date, agilentDate);
 	}
 
 	@Test
@@ -143,7 +146,7 @@ public class DateSupport_1_Test {
 		TimeZone.setDefault(TimeZone.getTimeZone("CEST"));
 		Date test = new Date(1157111760000l);
 		Date date = DateSupport.getDate(agilentDate);
-		assertEquals(agilentDate, test, date);
+		assertEquals(test, date, agilentDate);
 	}
 
 	@Test
@@ -154,7 +157,7 @@ public class DateSupport_1_Test {
 		TimeZone.setDefault(TimeZone.getTimeZone("CEST"));
 		Date test = new Date(1161042120000l);
 		Date date = DateSupport.getDate(agilentDate);
-		assertEquals(agilentDate, test, date);
+		assertEquals(test, date, agilentDate);
 	}
 
 	@Test
@@ -165,7 +168,7 @@ public class DateSupport_1_Test {
 		TimeZone.setDefault(TimeZone.getTimeZone("CET"));
 		Date test = new Date(1226259240000l);
 		Date date = DateSupport.getDate(agilentDate);
-		assertEquals(agilentDate, test, date);
+		assertEquals(test, date, agilentDate);
 	}
 
 	@Test
@@ -176,6 +179,6 @@ public class DateSupport_1_Test {
 		TimeZone.setDefault(TimeZone.getTimeZone("CET"));
 		Date test = new Date(1198302660000l);
 		Date date = DateSupport.getDate(agilentDate);
-		assertEquals(agilentDate, test, date);
+		assertEquals(test, date, agilentDate);
 	}
 }

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cms.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cms.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.msd.converter.supplier.cms.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.msd.converter.supplier.cms;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cms.fragment.test/src/net/openchrom/msd/converter/supplier/cms/converter/ImportConverter_1_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cms.fragment.test/src/net/openchrom/msd/converter/supplier/cms/converter/ImportConverter_1_ITest.java
@@ -14,7 +14,7 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cms.converter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 
@@ -24,17 +24,20 @@ import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cms.TestPathHelper;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class ImportConverter_1_ITest {
 
 	private IMassSpectra massSpectra;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		File importFile = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_MASS_SPECTRA_1));
 		IDatabaseImportConverter importConverter = new DatabaseImportConverter();

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cms.fragment.test/src/net/openchrom/msd/converter/supplier/cms/converter/ImportConverter_2_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cms.fragment.test/src/net/openchrom/msd/converter/supplier/cms/converter/ImportConverter_2_ITest.java
@@ -14,7 +14,7 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cms.converter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 
@@ -24,17 +24,20 @@ import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cms.TestPathHelper;
 import net.openchrom.msd.converter.supplier.cms.model.ICalibratedVendorLibraryMassSpectrum;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class ImportConverter_2_ITest {
 
 	private IMassSpectra massSpectra;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File importFile = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_MASS_SPECTRA_2));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cms.fragment.test/src/net/openchrom/msd/converter/supplier/cms/converter/ImportConverter_3_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cms.fragment.test/src/net/openchrom/msd/converter/supplier/cms/converter/ImportConverter_3_ITest.java
@@ -14,7 +14,7 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cms.converter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.util.List;
@@ -24,20 +24,23 @@ import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cms.PathResolver;
 import net.openchrom.msd.converter.supplier.cms.TestPathHelper;
 import net.openchrom.msd.converter.supplier.cms.model.ICalibratedVendorMassSpectrum;
 import net.openchrom.msd.converter.supplier.cms.model.IIonMeasurement;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class ImportConverter_3_ITest {
 
 	private IMassSpectra massSpectra;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		File importFile = new File(PathResolver.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_MASS_SPECTRA_3));
 		IDatabaseImportConverter importConverter = new DatabaseImportConverter();

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cms.fragment.test/src/net/openchrom/msd/converter/supplier/cms/converter/ReImportConverter_1_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cms.fragment.test/src/net/openchrom/msd/converter/supplier/cms/converter/ReImportConverter_1_ITest.java
@@ -14,7 +14,7 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cms.converter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 
@@ -24,20 +24,23 @@ import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cms.PathResolver;
 import net.openchrom.msd.converter.supplier.cms.TestPathHelper;
 import net.openchrom.msd.converter.supplier.cms.model.ICalibratedVendorLibraryMassSpectrum;
 import net.openchrom.msd.converter.supplier.cms.model.ICalibratedVendorMassSpectrum;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class ReImportConverter_1_ITest {
 
 	private IMassSpectra massSpectra1, massSpectra2;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		IDatabaseImportConverter importConverter = new DatabaseImportConverter();
 		IDatabaseExportConverter exportConverter = new DatabaseExportConverter();

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.cms.fragment.test/src/net/openchrom/msd/converter/supplier/cms/converter/ReImportConverter_2_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.cms.fragment.test/src/net/openchrom/msd/converter/supplier/cms/converter/ReImportConverter_2_ITest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.cms.converter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 
@@ -23,19 +23,22 @@ import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.cms.PathResolver;
 import net.openchrom.msd.converter.supplier.cms.TestPathHelper;
 import net.openchrom.msd.converter.supplier.cms.model.ICalibratedVendorLibraryMassSpectrum;
 import net.openchrom.msd.converter.supplier.cms.model.ICalibratedVendorMassSpectrum;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class ReImportConverter_2_ITest {
 
 	private IMassSpectra massSpectra1, massSpectra2;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		IDatabaseImportConverter importConverter = new DatabaseImportConverter();

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.gaml.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.gaml.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.msd.converter.supplier.gaml.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.msd.converter.supplier.gaml;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.gaml.fragment.test/src/net/openchrom/msd/converter/supplier/gaml/fragment/test/MicromassMasslynx_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.gaml.fragment.test/src/net/openchrom/msd/converter/supplier/gaml/fragment/test/MicromassMasslynx_ITest.java
@@ -12,26 +12,29 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.gaml.fragment.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.gaml.PathResolver;
 import net.openchrom.msd.converter.supplier.gaml.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class MicromassMasslynx_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.MASSLYNX));
 		ChromatogramImportConverter importConverter = new ChromatogramImportConverter();

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.gaml.fragment.test/src/net/openchrom/msd/converter/supplier/gaml/fragment/test/Xcalibur_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.gaml.fragment.test/src/net/openchrom/msd/converter/supplier/gaml/fragment/test/Xcalibur_ITest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.gaml.fragment.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
@@ -21,17 +21,20 @@ import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.gaml.PathResolver;
 import net.openchrom.msd.converter.supplier.gaml.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class Xcalibur_ITest {
 
 	private IChromatogramMSD chromatogram;
 
-	@Before
+	@BeforeAll
 	public void setUp() throws Exception {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.XCALIBUR));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.mgf.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.mgf.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.msd.converter.supplier.mgf.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.msd.converter.supplier.mgf;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.mgf.fragment.test/src/net/openchrom/msd/converter/supplier/mgf/converter/MassSpectrumExportConverter_1_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.mgf.fragment.test/src/net/openchrom/msd/converter/supplier/mgf/converter/MassSpectrumExportConverter_1_ITest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.mgf.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -25,11 +25,14 @@ import org.eclipse.chemclipse.msd.model.implementation.MassSpectra;
 import org.eclipse.chemclipse.msd.model.implementation.ScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.mgf.PathResolver;
 import net.openchrom.msd.converter.supplier.mgf.TestPathHelper;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumExportConverter_1_ITest {
 
 	@Test

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.mgf.fragment.test/src/net/openchrom/msd/converter/supplier/mgf/converter/MassSpectrumImportConverter_MS1_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.mgf.fragment.test/src/net/openchrom/msd/converter/supplier/mgf/converter/MassSpectrumImportConverter_MS1_ITest.java
@@ -13,16 +13,16 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.mgf.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import net.openchrom.msd.converter.supplier.mgf.TestPathHelper;
 
@@ -30,7 +30,7 @@ public class MassSpectrumImportConverter_MS1_ITest {
 
 	private static IMassSpectra massSpectra;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 
 		File file = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_MS_1));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.mgf.fragment.test/src/net/openchrom/msd/converter/supplier/mgf/converter/MassSpectrumImportConverter_MSforID_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.mgf.fragment.test/src/net/openchrom/msd/converter/supplier/mgf/converter/MassSpectrumImportConverter_MSforID_ITest.java
@@ -12,16 +12,16 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.mgf.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import net.openchrom.msd.converter.supplier.mgf.TestPathHelper;
 
@@ -29,7 +29,7 @@ public class MassSpectrumImportConverter_MSforID_ITest {
 
 	private static IMassSpectra massSpectra;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 
 		File file = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_MSFORID_TESTMIX));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.mgf.fragment.test/src/net/openchrom/msd/converter/supplier/mgf/converter/MassSpectrumImportConverter_ProteinPilot_Many_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.mgf.fragment.test/src/net/openchrom/msd/converter/supplier/mgf/converter/MassSpectrumImportConverter_ProteinPilot_Many_ITest.java
@@ -12,16 +12,16 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.mgf.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import net.openchrom.msd.converter.supplier.mgf.TestPathHelper;
 
@@ -29,7 +29,7 @@ public class MassSpectrumImportConverter_ProteinPilot_Many_ITest {
 
 	private static IMassSpectra massSpectra;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 
 		File file = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_PROTEINPILOT_MANY_ELEMENTS));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.mgf.fragment.test/src/net/openchrom/msd/converter/supplier/mgf/converter/MassSpectrumImportConverter_ProteinPilot_Single_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.mgf.fragment.test/src/net/openchrom/msd/converter/supplier/mgf/converter/MassSpectrumImportConverter_ProteinPilot_Single_ITest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.mgf.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
@@ -21,8 +21,8 @@ import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import net.openchrom.msd.converter.supplier.mgf.TestPathHelper;
 
@@ -30,7 +30,7 @@ public class MassSpectrumImportConverter_ProteinPilot_Single_ITest {
 
 	private static IMassSpectra massSpectra;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 
 		File file = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_PROTEINPILOT_SINGLE_ELEMENT));

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.mz5.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.mz5.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.msd.converter.supplier.mz5.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.msd.converter.supplier.mz5;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.mz5.fragment.test/src/net/openchrom/msd/converter/supplier/mz5/fragment/test/ChromatogramImportConverter_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.mz5.fragment.test/src/net/openchrom/msd/converter/supplier/mz5/fragment/test/ChromatogramImportConverter_ITest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.mz5.fragment.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
@@ -22,18 +22,21 @@ import org.eclipse.chemclipse.msd.model.core.IIon;
 import org.eclipse.chemclipse.msd.model.core.IRegularMassSpectrum;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.mz5.PathResolver;
 import net.openchrom.msd.converter.supplier.mz5.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportConverter_ITest {
 
-	private static IChromatogramMSD chromatogram;
+	private IChromatogramMSD chromatogram;
 
-	@BeforeClass
-	public static void setUp() {
+	@BeforeAll
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TESTFILE));
 		ChromatogramImportConverter importConverter = new ChromatogramImportConverter();

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.mzdb.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.mzdb.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.msd.converter.supplier.mzdb.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.msd.converter.supplier.mzdb;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="[5.12.0,6.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.mzdb.fragment.test/src/net/openchrom/msd/converter/supplier/mzdb/fragment/test/ChromatogramImportConverter_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.mzdb.fragment.test/src/net/openchrom/msd/converter/supplier/mzdb/fragment/test/ChromatogramImportConverter_ITest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.mzdb.fragment.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
@@ -22,18 +22,21 @@ import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.support.history.IEditInformation;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.mzdb.PathResolver;
 import net.openchrom.msd.converter.supplier.mzdb.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportConverter_ITest {
 
-	private static IChromatogramMSD chromatogram;
+	private IChromatogramMSD chromatogram;
 
-	@BeforeClass
-	public static void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TESTFILE));
 		ChromatogramImportConverter importConverter = new ChromatogramImportConverter();

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.mzmlb.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.mzmlb.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.msd.converter.supplier.mzmlb.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.msd.converter.supplier.mzmlb;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.mzmlb.fragment.test/src/net/openchrom/msd/converter/supplier/mzmlb/fragment/test/ChromatogramImportConverter_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.mzmlb.fragment.test/src/net/openchrom/msd/converter/supplier/mzmlb/fragment/test/ChromatogramImportConverter_ITest.java
@@ -12,26 +12,29 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.mzmlb.fragment.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.msd.model.core.IChromatogramMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.mzmlb.PathResolver;
 import net.openchrom.msd.converter.supplier.mzmlb.converter.ChromatogramImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportConverter_ITest {
 
-	private static IChromatogramMSD chromatogram;
+	private IChromatogramMSD chromatogram;
 
-	@BeforeClass
-	public static void setUp() {
+	@BeforeAll
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TESTFILE));
 		ChromatogramImportConverter importConverter = new ChromatogramImportConverter();

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.pkf.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.pkf.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.msd.converter.supplier.pkf.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.msd.converter.supplier.pkf;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/openchrom/tests/net.openchrom.msd.converter.supplier.pkf.fragment.test/src/net/openchrom/msd/converter/supplier/pkf/converter/MassSpectrumImportConverter_Ecoli_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.converter.supplier.pkf.fragment.test/src/net/openchrom/msd/converter/supplier/pkf/converter/MassSpectrumImportConverter_Ecoli_ITest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package net.openchrom.msd.converter.supplier.pkf.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
@@ -23,17 +23,20 @@ import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.msd.converter.supplier.pkf.TestPathHelper;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class MassSpectrumImportConverter_Ecoli_ITest {
 
-	private static IMassSpectra massSpectra;
+	private IMassSpectra massSpectra;
 
-	@BeforeClass
-	public static void setUp() {
+	@BeforeAll
+	public void setUp() {
 
 		File file = new File(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_IMPORT_ECOLI));
 		DatabaseImportConverter importConverter = new DatabaseImportConverter();

--- a/openchrom/tests/net.openchrom.msd.process.supplier.cms.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.msd.process.supplier.cms.fragment.test/META-INF/MANIFEST.MF
@@ -7,5 +7,5 @@ Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.msd.process.supplier.cms;bundle-version="1.5.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.12.0"
-Import-Package: net.openchrom.msd.converter.supplier.cms.io
+Import-Package: org.junit.jupiter.api;version="[5.12.0,6.0.0)"
+Require-Bundle: net.openchrom.msd.converter.supplier.cms;bundle-version="1.5.0"

--- a/openchrom/tests/net.openchrom.msd.process.supplier.cms.fragment.test/src/net/openchrom/msd/process/supplier/cms/core/MassSpectraDecomposition_1_ITest.java
+++ b/openchrom/tests/net.openchrom.msd.process.supplier.cms.fragment.test/src/net/openchrom/msd/process/supplier/cms/core/MassSpectraDecomposition_1_ITest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package net.openchrom.msd.process.supplier.cms.core;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -20,7 +20,7 @@ import java.io.IOException;
 import org.eclipse.chemclipse.msd.model.core.IMassSpectra;
 import org.eclipse.chemclipse.msd.model.core.IScanMSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import net.openchrom.msd.converter.supplier.cms.io.MassSpectrumReader;
 import net.openchrom.msd.converter.supplier.cms.model.ICalibratedVendorLibraryMassSpectrum;

--- a/openchrom/tests/net.openchrom.nmr.converter.supplier.gaml.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.nmr.converter.supplier.gaml.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.nmr.converter.supplier.gaml.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.nmr.converter.supplier.gaml;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/openchrom/tests/net.openchrom.nmr.converter.supplier.gaml.fragment.test/src/net/openchrom/csd/converter/supplier/gaml/fragment/test/BrukerXWinNMR1D_ITest.java
+++ b/openchrom/tests/net.openchrom.nmr.converter.supplier.gaml.fragment.test/src/net/openchrom/csd/converter/supplier/gaml/fragment/test/BrukerXWinNMR1D_ITest.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package net.openchrom.csd.converter.supplier.gaml.fragment.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.util.Collection;
@@ -23,18 +23,21 @@ import org.eclipse.chemclipse.model.core.IComplexSignalMeasurement;
 import org.eclipse.chemclipse.nmr.model.core.ISpectrumNMR;
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.nmr.converter.supplier.gaml.PathResolver;
 import net.openchrom.nmr.converter.supplier.gaml.converter.ScanImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class BrukerXWinNMR1D_ITest {
 
-	private static Collection<IComplexSignalMeasurement<?>> complexSignals;
+	private Collection<IComplexSignalMeasurement<?>> complexSignals;
 
-	@BeforeClass
-	public static void setUp() {
+	@BeforeAll
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.BRUKER_XWINNMR_1D));
 		ScanImportConverter importConverter = new ScanImportConverter();

--- a/openchrom/tests/net.openchrom.vsd.converter.supplier.gaml.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.vsd.converter.supplier.gaml.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.vsd.converter.supplier.gaml.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.vsd.converter.supplier.gaml;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/openchrom/tests/net.openchrom.vsd.converter.supplier.gaml.fragment.test/src/net/openchrom/vsd/converter/supplier/gaml/fragment/test/Omnic_FTIR_ITest.java
+++ b/openchrom/tests/net.openchrom.vsd.converter.supplier.gaml.fragment.test/src/net/openchrom/vsd/converter/supplier/gaml/fragment/test/Omnic_FTIR_ITest.java
@@ -13,26 +13,29 @@
  *******************************************************************************/
 package net.openchrom.vsd.converter.supplier.gaml.fragment.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.vsd.converter.supplier.gaml.PathResolver;
 import net.openchrom.vsd.converter.supplier.gaml.converter.ScanImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class Omnic_FTIR_ITest {
 
-	private static ISpectrumVSD spectrumVSD;
+	private ISpectrumVSD spectrumVSD;
 
-	@BeforeClass
-	public static void setUp() {
+	@BeforeAll
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TN_OMNIC_FTIR));
 		ScanImportConverter importConverter = new ScanImportConverter();

--- a/openchrom/tests/net.openchrom.vsd.converter.supplier.gaml.fragment.test/src/net/openchrom/vsd/converter/supplier/gaml/fragment/test/Omnic_Raman_ITest.java
+++ b/openchrom/tests/net.openchrom.vsd.converter.supplier.gaml.fragment.test/src/net/openchrom/vsd/converter/supplier/gaml/fragment/test/Omnic_Raman_ITest.java
@@ -12,26 +12,29 @@
  *******************************************************************************/
 package net.openchrom.vsd.converter.supplier.gaml.fragment.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.vsd.model.core.ISpectrumVSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.vsd.converter.supplier.gaml.PathResolver;
 import net.openchrom.vsd.converter.supplier.gaml.converter.ScanImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class Omnic_Raman_ITest {
 
-	private static ISpectrumVSD spectrumVSD;
+	private ISpectrumVSD spectrumVSD;
 
-	@BeforeClass
-	public static void setUp() {
+	@BeforeAll
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TN_OMNIC_RAMAN));
 		ScanImportConverter importConverter = new ScanImportConverter();

--- a/openchrom/tests/net.openchrom.wsd.converter.supplier.abif.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.wsd.converter.supplier.abif.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.wsd.converter.supplier.abif.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.wsd.converter.supplier.abif;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/openchrom/tests/net.openchrom.wsd.converter.supplier.abif.fragment.test/src/net/openchrom/wsd/converter/supplier/abif/io/AbiPrism3100GeneticAnalyser_ITest.java
+++ b/openchrom/tests/net.openchrom.wsd.converter.supplier.abif.fragment.test/src/net/openchrom/wsd/converter/supplier/abif/io/AbiPrism3100GeneticAnalyser_ITest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package net.openchrom.wsd.converter.supplier.abif.io;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 
@@ -22,17 +22,20 @@ import org.eclipse.chemclipse.wsd.converter.chromatogram.ChromatogramConverterWS
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 import org.eclipse.chemclipse.wsd.model.core.IScanWSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.wsd.converter.supplier.abif.ABIF;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class AbiPrism3100GeneticAnalyser_ITest {
 
-	private static IChromatogramWSD chromatogram;
+	private IChromatogramWSD chromatogram;
 
-	@BeforeClass
-	public static void setUp() {
+	@BeforeAll
+	public void setUp() {
 
 		File fileImport = new File(ABIF.getAbsolutePath(ABIF.TESTFILE_IMPORT_3100_AB1));
 		IProcessingInfo<IChromatogramWSD> processingInfo = ChromatogramConverterWSD.getInstance().convert(fileImport, ABIF.EXTENSION_POINT_ID, new NullProgressMonitor());

--- a/openchrom/tests/net.openchrom.wsd.converter.supplier.abif.fragment.test/src/net/openchrom/wsd/converter/supplier/abif/io/AbiPrism310GeneticAnalyser_ITest.java
+++ b/openchrom/tests/net.openchrom.wsd.converter.supplier.abif.fragment.test/src/net/openchrom/wsd/converter/supplier/abif/io/AbiPrism310GeneticAnalyser_ITest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package net.openchrom.wsd.converter.supplier.abif.io;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 
@@ -21,18 +21,21 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.chromatogram.ChromatogramConverterWSD;
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.wsd.converter.supplier.abif.ABIF;
 import net.openchrom.wsd.converter.supplier.abif.model.IVendorChromatogram;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class AbiPrism310GeneticAnalyser_ITest {
 
-	private static IChromatogramWSD chromatogram;
+	private IChromatogramWSD chromatogram;
 
-	@BeforeClass
-	public static void setUp() {
+	@BeforeAll
+	public void setUp() {
 
 		File fileImport = new File(ABIF.getAbsolutePath(ABIF.TESTFILE_IMPORT_310_AB1));
 		IProcessingInfo<IChromatogramWSD> processingInfo = ChromatogramConverterWSD.getInstance().convert(fileImport, ABIF.EXTENSION_POINT_ID, new NullProgressMonitor());

--- a/openchrom/tests/net.openchrom.wsd.converter.supplier.abif.fragment.test/src/net/openchrom/wsd/converter/supplier/abif/io/AbiPrism3730GeneticAnalyser_ITest.java
+++ b/openchrom/tests/net.openchrom.wsd.converter.supplier.abif.fragment.test/src/net/openchrom/wsd/converter/supplier/abif/io/AbiPrism3730GeneticAnalyser_ITest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package net.openchrom.wsd.converter.supplier.abif.io;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 
@@ -21,17 +21,20 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.chromatogram.ChromatogramConverterWSD;
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.wsd.converter.supplier.abif.ABIF;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class AbiPrism3730GeneticAnalyser_ITest {
 
-	private static IChromatogramWSD chromatogram;
+	private IChromatogramWSD chromatogram;
 
-	@BeforeClass
-	public static void setUp() {
+	@BeforeAll
+	public void setUp() {
 
 		File fileImport = new File(ABIF.getAbsolutePath(ABIF.TESTFILE_IMPORT_3730_AB1));
 		IProcessingInfo<IChromatogramWSD> processingInfo = ChromatogramConverterWSD.getInstance().convert(fileImport, ABIF.EXTENSION_POINT_ID, new NullProgressMonitor());

--- a/openchrom/tests/net.openchrom.wsd.converter.supplier.abif.fragment.test/src/net/openchrom/wsd/converter/supplier/abif/io/EmptyFile_ITest.java
+++ b/openchrom/tests/net.openchrom.wsd.converter.supplier.abif.fragment.test/src/net/openchrom/wsd/converter/supplier/abif/io/EmptyFile_ITest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package net.openchrom.wsd.converter.supplier.abif.io;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
@@ -21,17 +21,20 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.chromatogram.ChromatogramConverterWSD;
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.wsd.converter.supplier.abif.ABIF;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class EmptyFile_ITest {
 
-	private static IChromatogramWSD chromatogram;
+	private IChromatogramWSD chromatogram;
 
-	@BeforeClass
-	public static void setUp() {
+	@BeforeAll
+	public void setUp() {
 
 		File fileImport = new File(ABIF.getAbsolutePath(ABIF.TESTFILE_IMPORT_EMPTY_AB1));
 		IProcessingInfo<IChromatogramWSD> processingInfo = ChromatogramConverterWSD.getInstance().convert(fileImport, ABIF.EXTENSION_POINT_ID, new NullProgressMonitor());

--- a/openchrom/tests/net.openchrom.wsd.converter.supplier.abif.fragment.test/src/net/openchrom/wsd/converter/supplier/abif/io/InvalidData_ITest.java
+++ b/openchrom/tests/net.openchrom.wsd.converter.supplier.abif.fragment.test/src/net/openchrom/wsd/converter/supplier/abif/io/InvalidData_ITest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package net.openchrom.wsd.converter.supplier.abif.io;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 
@@ -21,17 +21,20 @@ import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.converter.chromatogram.ChromatogramConverterWSD;
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.wsd.converter.supplier.abif.ABIF;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class InvalidData_ITest {
 
-	private static IChromatogramWSD chromatogram;
+	private IChromatogramWSD chromatogram;
 
-	@BeforeClass
-	public static void setUp() {
+	@BeforeAll
+	public void setUp() {
 
 		File fileImport = new File(ABIF.getAbsolutePath(ABIF.TESTFILE_IMPORT_FAKE_AB1));
 		IProcessingInfo<IChromatogramWSD> processingInfo = ChromatogramConverterWSD.getInstance().convert(fileImport, ABIF.EXTENSION_POINT_ID, new NullProgressMonitor());

--- a/openchrom/tests/net.openchrom.wsd.converter.supplier.animl.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.wsd.converter.supplier.animl.fragment.test/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-SymbolicName: net.openchrom.wsd.converter.supplier.animl.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.wsd.converter.supplier.animl;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0",
- org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"
+Require-Bundle: org.eclipse.chemclipse.xxd.converter.supplier.ocx;bundle-version="0.9.0"

--- a/openchrom/tests/net.openchrom.wsd.converter.supplier.animl.fragment.test/src/net/openchrom/wsd/converter/supplier/animl/converter/ChromatogramImportExport_ITest.java
+++ b/openchrom/tests/net.openchrom.wsd.converter.supplier.animl.fragment.test/src/net/openchrom/wsd/converter/supplier/animl/converter/ChromatogramImportExport_ITest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package net.openchrom.wsd.converter.supplier.animl.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
@@ -24,20 +24,23 @@ import org.eclipse.chemclipse.wsd.converter.chromatogram.ChromatogramConverterWS
 import org.eclipse.chemclipse.wsd.model.core.IChromatogramWSD;
 import org.eclipse.chemclipse.xxd.converter.supplier.ocx.versions.VersionConstants;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.wsd.converter.supplier.animl.TestPathHelper;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class ChromatogramImportExport_ITest {
 
-	private static IChromatogramWSD chromatogramImport;
-	private static IChromatogramWSD chromatogram;
-	private static File fileExport;
+	private IChromatogramWSD chromatogramImport;
+	private IChromatogramWSD chromatogram;
+	private File fileExport;
 
-	@BeforeClass
-	public static void setUp() {
+	@BeforeAll
+	public void setUp() {
 
 		/*
 		 * Import
@@ -80,8 +83,8 @@ public class ChromatogramImportExport_ITest {
 		}
 	}
 
-	@AfterClass
-	public static void tearDown() {
+	@AfterAll
+	public void tearDown() {
 
 		fileExport.delete();
 	}

--- a/openchrom/tests/net.openchrom.wsd.converter.supplier.gaml.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.wsd.converter.supplier.gaml.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.wsd.converter.supplier.gaml.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.wsd.converter.supplier.gaml;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/openchrom/tests/net.openchrom.wsd.converter.supplier.gaml.fragment.test/src/net/openchrom/wsd/converter/supplier/gaml/fragment/test/Helios_ITest.java
+++ b/openchrom/tests/net.openchrom.wsd.converter.supplier.gaml.fragment.test/src/net/openchrom/wsd/converter/supplier/gaml/fragment/test/Helios_ITest.java
@@ -12,26 +12,29 @@
  *******************************************************************************/
 package net.openchrom.wsd.converter.supplier.gaml.fragment.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
 import org.eclipse.chemclipse.processing.core.IProcessingInfo;
 import org.eclipse.chemclipse.wsd.model.core.ISpectrumWSD;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.wsd.converter.supplier.gaml.PathResolver;
 import net.openchrom.wsd.converter.supplier.gaml.converter.ScanImportConverter;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class Helios_ITest {
 
-	private static ISpectrumWSD spectrumWSD;
+	private ISpectrumWSD spectrumWSD;
 
-	@BeforeClass
-	public static void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		File file = new File(PathResolver.getAbsolutePath(TestPathHelper.TS_HELIOS));
 		ScanImportConverter importConverter = new ScanImportConverter();

--- a/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.xxd.classifier.supplier.ratios.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.xxd.classifier.supplier.ratios;bundle-version="1.0.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/PeakRatioResult_1_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/PeakRatioResult_1_Test.java
@@ -12,23 +12,26 @@
  *******************************************************************************/
 package net.openchrom.xxd.classifier.supplier.ratios.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.xxd.classifier.result.ResultStatus;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.xxd.classifier.supplier.ratios.model.quant.QuantRatios;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class PeakRatioResult_1_Test {
 
 	private PeakRatioResult peakRatioResult;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		peakRatioResult = new PeakRatioResult(ResultStatus.OK, "Test", new QuantRatios());
 	}

--- a/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/PeakRatioResult_2_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/PeakRatioResult_2_Test.java
@@ -12,23 +12,26 @@
  *******************************************************************************/
 package net.openchrom.xxd.classifier.supplier.ratios.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.xxd.classifier.result.ResultStatus;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.xxd.classifier.supplier.ratios.model.time.TimeRatios;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class PeakRatioResult_2_Test {
 
 	private PeakRatioResult peakRatioResult;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		peakRatioResult = new PeakRatioResult(ResultStatus.OK, "Test", new TimeRatios());
 	}

--- a/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/PeakRatioResult_3_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/PeakRatioResult_3_Test.java
@@ -12,23 +12,26 @@
  *******************************************************************************/
 package net.openchrom.xxd.classifier.supplier.ratios.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 
 import org.eclipse.chemclipse.chromatogram.xxd.classifier.result.ResultStatus;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import net.openchrom.xxd.classifier.supplier.ratios.model.trace.TraceRatios;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class PeakRatioResult_3_Test {
 
 	private PeakRatioResult peakRatioResult;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeAll
+	public void setUp() {
 
 		peakRatioResult = new PeakRatioResult(ResultStatus.OK, "Test", new TraceRatios());
 	}

--- a/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/quant/QuantRatio_1_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/quant/QuantRatio_1_Test.java
@@ -12,21 +12,17 @@
  *******************************************************************************/
 package net.openchrom.xxd.classifier.supplier.ratios.model.quant;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class QuantRatio_1_Test {
 
-	private QuantRatio peakRatio;
-
-	@Before
-	public void setUp() throws Exception {
-
-		peakRatio = new QuantRatio();
-	}
+	private QuantRatio peakRatio = new QuantRatio();
 
 	@Test
 	public void test1() {

--- a/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/quant/QuantRatio_2_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/quant/QuantRatio_2_Test.java
@@ -12,21 +12,17 @@
  *******************************************************************************/
 package net.openchrom.xxd.classifier.supplier.ratios.model.quant;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class QuantRatio_2_Test {
 
-	private QuantRatio peakRatio;
-
-	@Before
-	public void setUp() throws Exception {
-
-		peakRatio = new QuantRatio();
-	}
+	private QuantRatio peakRatio = new QuantRatio();
 
 	@Test
 	public void test1() {

--- a/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/time/TimeRatio_1_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/time/TimeRatio_1_Test.java
@@ -12,21 +12,17 @@
  *******************************************************************************/
 package net.openchrom.xxd.classifier.supplier.ratios.model.time;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TimeRatio_1_Test {
 
-	private TimeRatio peakRatio;
-
-	@Before
-	public void setUp() throws Exception {
-
-		peakRatio = new TimeRatio();
-	}
+	private TimeRatio peakRatio = new TimeRatio();
 
 	@Test
 	public void test1() {

--- a/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/time/TimeRatio_2_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/time/TimeRatio_2_Test.java
@@ -12,21 +12,17 @@
  *******************************************************************************/
 package net.openchrom.xxd.classifier.supplier.ratios.model.time;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TimeRatio_2_Test {
 
-	private TimeRatio peakRatio;
-
-	@Before
-	public void setUp() throws Exception {
-
-		peakRatio = new TimeRatio();
-	}
+	private TimeRatio peakRatio = new TimeRatio();
 
 	@Test
 	public void test1() {

--- a/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/trace/TraceRatio_1_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/trace/TraceRatio_1_Test.java
@@ -12,21 +12,17 @@
  *******************************************************************************/
 package net.openchrom.xxd.classifier.supplier.ratios.model.trace;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TraceRatio_1_Test {
 
-	private TraceRatio peakRatio;
-
-	@Before
-	public void setUp() throws Exception {
-
-		peakRatio = new TraceRatio();
-	}
+	private TraceRatio peakRatio = new TraceRatio();
 
 	@Test
 	public void test1() {

--- a/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/trace/TraceRatio_2_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.classifier.supplier.ratios.fragment.test/src/net/openchrom/xxd/classifier/supplier/ratios/model/trace/TraceRatio_2_Test.java
@@ -12,21 +12,17 @@
  *******************************************************************************/
 package net.openchrom.xxd.classifier.supplier.ratios.model.trace;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class TraceRatio_2_Test {
 
-	private TraceRatio peakRatio;
-
-	@Before
-	public void setUp() throws Exception {
-
-		peakRatio = new TraceRatio();
-	}
+	private TraceRatio peakRatio = new TraceRatio();
 
 	@Test
 	public void test1() {

--- a/openchrom/tests/net.openchrom.xxd.identifier.supplier.cdk.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.xxd.identifier.supplier.cdk.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.xxd.identifier.supplier.cdk.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: ChemClipse
 Fragment-Host: net.openchrom.xxd.identifier.supplier.cdk;bundle-version="0.8.0"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.11.0"

--- a/openchrom/tests/net.openchrom.xxd.identifier.supplier.cdk.fragment.test/src/net/openchrom/xxd/identifier/supplier/cdk/converter/CDKMolToMoleculeConverter_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.identifier.supplier.cdk.fragment.test/src/net/openchrom/xxd/identifier/supplier/cdk/converter/CDKMolToMoleculeConverter_Test.java
@@ -12,12 +12,15 @@
  *******************************************************************************/
 package net.openchrom.xxd.identifier.supplier.cdk.converter;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.openscience.cdk.interfaces.IAtomContainer;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class CDKMolToMoleculeConverter_Test {
 
 	private CDKMolToMoleculeConverter converter = new CDKMolToMoleculeConverter();

--- a/openchrom/tests/net.openchrom.xxd.identifier.supplier.cdk.fragment.test/src/net/openchrom/xxd/identifier/supplier/cdk/converter/CDKSmilesToMoleculeConverter_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.identifier.supplier.cdk.fragment.test/src/net/openchrom/xxd/identifier/supplier/cdk/converter/CDKSmilesToMoleculeConverter_Test.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package net.openchrom.xxd.identifier.supplier.cdk.converter;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openscience.cdk.interfaces.IAtomContainer;
 
 public class CDKSmilesToMoleculeConverter_Test {

--- a/openchrom/tests/net.openchrom.xxd.identifier.supplier.cdk.fragment.test/src/net/openchrom/xxd/identifier/supplier/cdk/converter/OPSINIupacToMoleculeConverter_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.identifier.supplier.cdk.fragment.test/src/net/openchrom/xxd/identifier/supplier/cdk/converter/OPSINIupacToMoleculeConverter_Test.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package net.openchrom.xxd.identifier.supplier.cdk.converter;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openscience.cdk.interfaces.IAtomContainer;
 
 public class OPSINIupacToMoleculeConverter_Test {

--- a/openchrom/tests/net.openchrom.xxd.identifier.supplier.cdk.fragment.test/src/net/openchrom/xxd/identifier/supplier/cdk/converter/TanimotoSimilarity_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.identifier.supplier.cdk.fragment.test/src/net/openchrom/xxd/identifier/supplier/cdk/converter/TanimotoSimilarity_Test.java
@@ -12,10 +12,12 @@
  *******************************************************************************/
 package net.openchrom.xxd.identifier.supplier.cdk.converter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;
@@ -30,15 +32,16 @@ import org.openscience.cdk.smiles.SmilesParser;
 /**
  * T. T. Tanimoto, (1958) “An elementary mathematical theory of classification and prediction,” IBM Internal Report.
  */
+@TestInstance(Lifecycle.PER_CLASS)
 public class TanimotoSimilarity_Test {
 
-	private static SmilesParser smilesParser = new SmilesParser(DefaultChemObjectBuilder.getInstance());
+	private SmilesParser smilesParser = new SmilesParser(DefaultChemObjectBuilder.getInstance());
 
-	private static IAtomContainer benzene;
-	private static IAtomContainer pyridine;
+	private IAtomContainer benzene;
+	private IAtomContainer pyridine;
 
-	@BeforeClass
-	public static void setUp() throws InvalidSmilesException {
+	@BeforeAll
+	public void setUp() throws InvalidSmilesException {
 
 		benzene = smilesParser.parseSmiles("C1=CC=CC=C1");
 		pyridine = smilesParser.parseSmiles("C1=CC=NC=C1");

--- a/openchrom/tests/net.openchrom.xxd.identifier.supplier.cdk.fragment.test/src/net/openchrom/xxd/identifier/supplier/cdk/support/MoleculeMassCalculator_1_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.identifier.supplier.cdk.fragment.test/src/net/openchrom/xxd/identifier/supplier/cdk/support/MoleculeMassCalculator_1_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package net.openchrom.xxd.identifier.supplier.cdk.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 
 public class MoleculeMassCalculator_1_Test {

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/META-INF/MANIFEST.MF
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: net.openchrom.xxd.process.supplier.templates.fragment.test
 Bundle-Version: 1.5.25.qualifier
 Bundle-Vendor: OpenChrom
 Fragment-Host: net.openchrom.xxd.process.supplier.templates;bundle-version="1.5.1"
+Import-Package: org.junit.jupiter.api;version="5.12.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/AssignerReference_1_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/AssignerReference_1_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AssignerReference_1_Test {
 

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/AssignerReference_2_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/AssignerReference_2_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AssignerReference_2_Test {
 

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/AssignerStandard_1_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/AssignerStandard_1_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AssignerStandard_1_Test {
 

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/AssignerStandard_2_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/AssignerStandard_2_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AssignerStandard_2_Test {
 

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/DetectorSetting_1_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/DetectorSetting_1_Test.java
@@ -12,10 +12,10 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.chemclipse.model.core.PeakType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DetectorSetting_1_Test {
 

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/DetectorSetting_2_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/DetectorSetting_2_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DetectorSetting_2_Test {
 

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/IdentifierSetting_1_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/IdentifierSetting_1_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IdentifierSetting_1_Test {
 

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/IdentifierSetting_2_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/IdentifierSetting_2_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IdentifierSetting_2_Test {
 

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/IntegratorSetting_1_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/IntegratorSetting_1_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IntegratorSetting_1_Test {
 

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/IntegratorSetting_2_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/IntegratorSetting_2_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IntegratorSetting_2_Test {
 

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/Visibility_1_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/Visibility_1_Test.java
@@ -12,11 +12,11 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Visibility_1_Test {
 

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/support/PeakSupport_1_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/support/PeakSupport_1_Test.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.support;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.chemclipse.csd.model.core.IPeakCSD;
 import org.eclipse.chemclipse.csd.model.core.IPeakModelCSD;
@@ -39,7 +39,7 @@ import org.eclipse.chemclipse.wsd.model.core.implementation.PeakModelWSD;
 import org.eclipse.chemclipse.wsd.model.core.implementation.PeakWSD;
 import org.eclipse.chemclipse.wsd.model.core.implementation.ScanSignalWSD;
 import org.eclipse.chemclipse.wsd.model.core.implementation.ScanWSD;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PeakSupport_1_Test {
 

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/util/TraceUtil_1_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/util/TraceUtil_1_Test.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.util;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.chemclipse.model.core.IPeak;
 import org.eclipse.chemclipse.model.implementation.Peak;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TraceUtil_1_Test {
 

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/util/TracesValidator_1_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/util/TracesValidator_1_Test.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.util;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TracesValidator_1_Test {
 

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/util/TracesValidator_2_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/util/TracesValidator_2_Test.java
@@ -12,15 +12,15 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
 import org.eclipse.chemclipse.support.validators.TraceValidator;
 import org.eclipse.core.runtime.IStatus;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TracesValidator_2_Test {
 

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/util/TracesValidator_3_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/util/TracesValidator_3_Test.java
@@ -12,15 +12,15 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
 import org.eclipse.chemclipse.support.validators.TraceValidator;
 import org.eclipse.core.runtime.IStatus;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TracesValidator_3_Test {
 

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/util/TracesValidator_4_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/util/TracesValidator_4_Test.java
@@ -12,15 +12,15 @@
  *******************************************************************************/
 package net.openchrom.xxd.process.supplier.templates.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
 import org.eclipse.chemclipse.support.validators.TraceValidator;
 import org.eclipse.core.runtime.IStatus;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TracesValidator_4_Test {
 


### PR DESCRIPTION
This allows for shared objects that don't have to be static, so the garbage collection does its job while the tests are still running. Otherwise it accumulates and releases only when all tests have run, which is a behavior I didn't anticipate. So now the tests become fast and memory efficient.