### PR TITLE
Rename variable to PositionRelativePeakName to avoid confusion using it.

### DIFF
--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/AbstractTemplateLabelProvider.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/AbstractTemplateLabelProvider.java
@@ -23,7 +23,7 @@ public abstract class AbstractTemplateLabelProvider extends AbstractChemClipseLa
 	public static final String POSITION_START = "Position Start";
 	public static final String POSITION_STOP = "Position Stop";
 	public static final String POSITION_DIRECTIVE = "Position Directive";
-	public static final String REFERENCE_IDENTIFIER = "Reference Identifier";
+	public static final String POSITION_RELATIVE_PEAK_NAME = "Position Relative (Peak Name)";
 	public static final String TRACES = "Traces";
 	public static final String NAME = "Name";
 	public static final String PEAK_TYPE = "Peak Type";
@@ -31,7 +31,7 @@ public abstract class AbstractTemplateLabelProvider extends AbstractChemClipseLa
 	public static final String CAS_NUMBER = "CAS";
 	public static final String COMMENTS = "Comments";
 	public static final String CONTRIBUTOR = "Contributor";
-	public static final String REFERENCE = "Reference";
+	public static final String REFERENCE_IDENTIFIER = "Reference Identifier";
 	public static final String IDENTIFIER = "Identifier";
 	public static final String INTEGRATOR = "Integrator";
 	public static final String REPORT_STRATEGY = "Strategy";

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/PeakDetectorEditingSupport.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/PeakDetectorEditingSupport.java
@@ -42,7 +42,7 @@ public class PeakDetectorEditingSupport extends AbstractTemplateEditingSupport {
 						return setting.getTraces();
 					case AbstractTemplateLabelProvider.OPTIMIZE_RANGE:
 						return setting.isOptimizeRange();
-					case AbstractTemplateLabelProvider.REFERENCE_IDENTIFIER:
+					case AbstractTemplateLabelProvider.POSITION_RELATIVE_PEAK_NAME:
 						return setting.getReferenceIdentifier();
 					case AbstractTemplateLabelProvider.NAME:
 						return setting.getName();
@@ -75,7 +75,7 @@ public class PeakDetectorEditingSupport extends AbstractTemplateEditingSupport {
 				case AbstractTemplateLabelProvider.OPTIMIZE_RANGE:
 					setting.setOptimizeRange((boolean)value);
 					break;
-				case AbstractTemplateLabelProvider.REFERENCE_IDENTIFIER:
+				case AbstractTemplateLabelProvider.POSITION_RELATIVE_PEAK_NAME:
 					String referenceIdentifier = ((String)value).trim();
 					setting.setReferenceIdentifier(referenceIdentifier);
 					break;

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/PeakDetectorLabelProvider.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/PeakDetectorLabelProvider.java
@@ -31,7 +31,7 @@ public class PeakDetectorLabelProvider extends AbstractTemplateLabelProvider {
 			PEAK_TYPE, //
 			TRACES, //
 			OPTIMIZE_RANGE, //
-			REFERENCE_IDENTIFIER, //
+			POSITION_RELATIVE_PEAK_NAME, //
 			NAME //
 	};
 	public static final int[] BOUNDS = { //

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/PeakIdentifierComparator.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/PeakIdentifierComparator.java
@@ -49,13 +49,13 @@ public class PeakIdentifierComparator extends AbstractRecordTableComparator impl
 					sortOrder = setting2.getContributor().compareTo(setting1.getContributor());
 					break;
 				case 7:
-					sortOrder = setting2.getReference().compareTo(setting1.getReference());
+					sortOrder = setting2.getReferenceIdentifier().compareTo(setting1.getReferenceIdentifier());
 					break;
 				case 8:
 					sortOrder = setting2.getTraces().compareTo(setting1.getTraces());
 					break;
 				case 9:
-					sortOrder = setting2.getReferenceIdentifier().compareTo(setting1.getReferenceIdentifier());
+					sortOrder = setting2.getPositionRelativePeakName().compareTo(setting1.getPositionRelativePeakName());
 					break;
 				default:
 					sortOrder = 0;

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/PeakIdentifierEditingSupport.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/PeakIdentifierEditingSupport.java
@@ -44,12 +44,12 @@ public class PeakIdentifierEditingSupport extends AbstractTemplateEditingSupport
 						return setting.getComments();
 					case AbstractTemplateLabelProvider.CONTRIBUTOR:
 						return setting.getContributor();
-					case AbstractTemplateLabelProvider.REFERENCE:
-						return setting.getReference();
-					case AbstractTemplateLabelProvider.TRACES:
-						return setting.getTraces();
 					case AbstractTemplateLabelProvider.REFERENCE_IDENTIFIER:
 						return setting.getReferenceIdentifier();
+					case AbstractTemplateLabelProvider.TRACES:
+						return setting.getTraces();
+					case AbstractTemplateLabelProvider.POSITION_RELATIVE_PEAK_NAME:
+						return setting.getPositionRelativePeakName();
 				}
 			}
 		}
@@ -74,8 +74,8 @@ public class PeakIdentifierEditingSupport extends AbstractTemplateEditingSupport
 				case AbstractTemplateLabelProvider.CONTRIBUTOR:
 					setting.setContributor(((String)value).trim());
 					break;
-				case AbstractTemplateLabelProvider.REFERENCE:
-					setting.setReference(((String)value).trim());
+				case AbstractTemplateLabelProvider.REFERENCE_IDENTIFIER:
+					setting.setReferenceIdentifier(((String)value).trim());
 					break;
 				case AbstractTemplateLabelProvider.TRACES:
 					String traces = ((String)value).trim();
@@ -85,8 +85,8 @@ public class PeakIdentifierEditingSupport extends AbstractTemplateEditingSupport
 						setting.setTraces(traces);
 					}
 					break;
-				case AbstractTemplateLabelProvider.REFERENCE_IDENTIFIER:
-					setting.setReferenceIdentifier(((String)value).trim());
+				case AbstractTemplateLabelProvider.POSITION_RELATIVE_PEAK_NAME:
+					setting.setPositionRelativePeakName(((String)value).trim());
 					break;
 			}
 

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/PeakIdentifierFilter.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/PeakIdentifierFilter.java
@@ -40,9 +40,10 @@ public class PeakIdentifierFilter extends ViewerFilter {
 			String cas = setting.getCasNumber();
 			String comments = setting.getComments();
 			String contributor = setting.getContributor();
-			String reference = setting.getReference();
+			String reference = setting.getReferenceIdentifier();
 			String traces = setting.getTraces();
 			String referenceIdentifier = setting.getReferenceIdentifier();
+			String positionReferencePeakName = setting.getPositionRelativePeakName();
 
 			if(!caseSensitive) {
 				searchText = searchText.toLowerCase();
@@ -53,6 +54,7 @@ public class PeakIdentifierFilter extends ViewerFilter {
 				reference = reference.toLowerCase();
 				traces = traces.toLowerCase();
 				referenceIdentifier = referenceIdentifier.toLowerCase();
+				positionReferencePeakName = positionReferencePeakName.toLowerCase();
 			}
 
 			if(name.contains(searchText)) {
@@ -80,6 +82,10 @@ public class PeakIdentifierFilter extends ViewerFilter {
 			}
 
 			if(referenceIdentifier.contains(searchText)) {
+				return true;
+			}
+
+			if(positionReferencePeakName.contains(searchText)) {
 				return true;
 			}
 		}

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/PeakIdentifierLabelProvider.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/PeakIdentifierLabelProvider.java
@@ -29,9 +29,9 @@ public class PeakIdentifierLabelProvider extends AbstractTemplateLabelProvider {
 			CAS_NUMBER, //
 			COMMENTS, //
 			CONTRIBUTOR, //
-			REFERENCE, //
+			REFERENCE_IDENTIFIER, //
 			TRACES, //
-			REFERENCE_IDENTIFIER //
+			POSITION_RELATIVE_PEAK_NAME //
 	};
 	public static final int[] BOUNDS = { //
 			200, //
@@ -83,13 +83,13 @@ public class PeakIdentifierLabelProvider extends AbstractTemplateLabelProvider {
 					text = setting.getContributor();
 					break;
 				case 7:
-					text = setting.getReference();
+					text = setting.getReferenceIdentifier();
 					break;
 				case 8:
 					text = setting.getTraces();
 					break;
 				case 9:
-					text = setting.getReferenceIdentifier();
+					text = setting.getPositionRelativePeakName();
 					break;
 				default:
 					text = "n.v.";

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/io/IdentifierExport.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/io/IdentifierExport.java
@@ -59,9 +59,9 @@ public class IdentifierExport extends AbstractChromatogramExportConverter implem
 				setting.setCasNumber(libraryInformation.getCasNumber());
 				setting.setComments(libraryInformation.getComments());
 				setting.setContributor(libraryInformation.getContributor());
-				setting.setReference(libraryInformation.getReferenceIdentifier());
+				setting.setReferenceIdentifier(libraryInformation.getReferenceIdentifier());
 				setting.setTraces(extractTraces(peak, numberTraces));
-				setting.setReferenceIdentifier("");
+				setting.setPositionRelativePeakName("");
 				identifierSettings.add(setting);
 			}
 		}

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/model/IdentifierSetting.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/model/IdentifierSetting.java
@@ -20,9 +20,13 @@ public class IdentifierSetting extends AbstractSetting {
 	private String casNumber = "";
 	private String comments = "";
 	private String contributor = "";
-	private String reference = "";
+	private String referenceIdentifier = ""; // ILibraryInformation->ReferenceIdentifier
 	private String traces = "";
-	private String referenceIdentifier = ""; // Used for relative retention time
+	/*
+	 * Used for a retention time or index relative
+	 * to a peak with the given identification.
+	 */
+	private String positionRelativePeakName = "";
 
 	public void copyFrom(IdentifierSetting setting) {
 
@@ -34,9 +38,9 @@ public class IdentifierSetting extends AbstractSetting {
 			setCasNumber(setting.getCasNumber());
 			setComments(setting.getComments());
 			setContributor(setting.getContributor());
-			setReference(setting.getReference());
-			setTraces(setting.getTraces());
 			setReferenceIdentifier(setting.getReferenceIdentifier());
+			setTraces(setting.getTraces());
+			setPositionRelativePeakName(setting.getPositionRelativePeakName());
 		}
 	}
 
@@ -80,14 +84,14 @@ public class IdentifierSetting extends AbstractSetting {
 		this.contributor = contributor;
 	}
 
-	public String getReference() {
+	public String getReferenceIdentifier() {
 
-		return reference;
+		return referenceIdentifier;
 	}
 
-	public void setReference(String reference) {
+	public void setReferenceIdentifier(String referenceIdentifier) {
 
-		this.reference = reference;
+		this.referenceIdentifier = referenceIdentifier;
 	}
 
 	public String getTraces() {
@@ -100,14 +104,14 @@ public class IdentifierSetting extends AbstractSetting {
 		this.traces = traces;
 	}
 
-	public String getReferenceIdentifier() {
+	public String getPositionRelativePeakName() {
 
-		return referenceIdentifier;
+		return positionRelativePeakName;
 	}
 
-	public void setReferenceIdentifier(String referenceIdentifier) {
+	public void setPositionRelativePeakName(String positionRelativePeakName) {
 
-		this.referenceIdentifier = referenceIdentifier;
+		this.positionRelativePeakName = positionRelativePeakName;
 	}
 
 	@Override

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/model/IdentifierSettings.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/model/IdentifierSettings.java
@@ -188,9 +188,9 @@ public class IdentifierSettings extends ArrayList<IdentifierSetting> implements 
 		entries.add(setting.getCasNumber());
 		entries.add(getFormattedString(setting.getComments()));
 		entries.add(getFormattedString(setting.getContributor()));
-		entries.add(getFormattedString(setting.getReference()));
-		entries.add(setting.getTraces());
 		entries.add(getFormattedString(setting.getReferenceIdentifier()));
+		entries.add(setting.getTraces());
+		entries.add(getFormattedString(setting.getPositionRelativePeakName()));
 		entries.add(setting.getPositionDirective().name());
 
 		compile(builder, entries);

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/peaks/AbstractPeakIdentifier.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/peaks/AbstractPeakIdentifier.java
@@ -91,7 +91,7 @@ public abstract class AbstractPeakIdentifier {
 	private void identifyPeak(List<? extends IPeak> peaks, IdentifierSetting identifierSetting, RetentionIndexMap retentionIndexMap, IProgressMonitor monitor) {
 
 		PeakSupport retentionTimeSupport = new PeakSupport();
-		IRetentionTimeRange retentionTimeRange = retentionTimeSupport.getRetentionTimeRange(peaks, identifierSetting, identifierSetting.getReferenceIdentifier(), retentionIndexMap);
+		IRetentionTimeRange retentionTimeRange = retentionTimeSupport.getRetentionTimeRange(peaks, identifierSetting, identifierSetting.getPositionRelativePeakName(), retentionIndexMap);
 		int startRetentionTime = retentionTimeRange.getStartRetentionTime();
 		int stopRetentionTime = retentionTimeRange.getStopRetentionTime();
 		TracesUtil tracesUtil = new TracesUtil();
@@ -113,7 +113,7 @@ public abstract class AbstractPeakIdentifier {
 								libraryInformation.setCasNumber(identifierSetting.getCasNumber());
 								libraryInformation.setComments(identifierSetting.getComments());
 								libraryInformation.setContributor(identifierSetting.getContributor());
-								libraryInformation.setReferenceIdentifier(identifierSetting.getReference());
+								libraryInformation.setReferenceIdentifier(identifierSetting.getReferenceIdentifier());
 								IComparisonResult comparisonResult = new ComparisonResult(matchFactor, matchFactor, matchFactor, matchFactor);
 								IIdentificationTarget identificationTarget = new IdentificationTarget(libraryInformation, comparisonResult);
 								identificationTarget.setIdentifier(PeakIdentifierSettings.IDENTIFIER_DESCRIPTION); // $NON-NLS-N$

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/support/PeakSupport.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/support/PeakSupport.java
@@ -139,7 +139,7 @@ public class PeakSupport {
 		return stopScan;
 	}
 
-	public RetentionTimeRange getRetentionTimeRange(List<? extends IPeak> peaks, AbstractSetting setting, String referenceIdentifier, RetentionIndexMap retentionIndexMap) {
+	public RetentionTimeRange getRetentionTimeRange(List<? extends IPeak> peaks, AbstractSetting setting, String positionRelativePeakName, RetentionIndexMap retentionIndexMap) {
 
 		/*
 		 * Retention Time (milliseconds)
@@ -147,11 +147,11 @@ public class PeakSupport {
 		int startRetentionTime = 0;
 		int stopRetentionTime = 0;
 
-		if(!referenceIdentifier.isEmpty()) {
+		if(!positionRelativePeakName.isEmpty()) {
 			/*
 			 * Position via Reference
 			 */
-			IPeak peak = getReferencePeak(peaks, referenceIdentifier);
+			IPeak peak = getReferencePeak(peaks, positionRelativePeakName);
 			if(peak != null) {
 				/*
 				 * If a reference identifier is set, the retention time range
@@ -439,12 +439,12 @@ public class PeakSupport {
 		return scanSignal;
 	}
 
-	private IPeak getReferencePeak(List<? extends IPeak> peaks, String referenceIdentifier) {
+	private IPeak getReferencePeak(List<? extends IPeak> peaks, String name) {
 
 		for(IPeak peak : peaks) {
 			ILibraryInformation libraryInformation = IIdentificationTarget.getLibraryInformation(peak);
 			if(libraryInformation != null) {
-				if(referenceIdentifier.equals(libraryInformation.getName())) {
+				if(name.equals(libraryInformation.getName())) {
 					return peak;
 				}
 			}

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/util/PeakIdentifierValidator.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/util/PeakIdentifierValidator.java
@@ -29,9 +29,9 @@ public class PeakIdentifierValidator extends AbstractTemplateValidator implement
 	private String casNumber = "";
 	private String comments = "";
 	private String contributor = "";
-	private String reference = "";
-	private String traces = "";
 	private String referenceIdentifier = "";
+	private String traces = "";
+	private String positionRelativePeakName = "";
 
 	@Override
 	public IStatus validate(Object value) {
@@ -61,14 +61,14 @@ public class PeakIdentifierValidator extends AbstractTemplateValidator implement
 						casNumber = parseString(values, 3);
 						comments = parseString(values, 4);
 						contributor = parseString(values, 5);
-						reference = parseString(values, 6);
+						referenceIdentifier = parseString(values, 6);
 						String traceValues = parseString(values, 7);
-						referenceIdentifier = parseString(values, 8, "");
+						positionRelativePeakName = parseString(values, 8, "");
 						positionDirective = parsePositionDirective(parseString(values, 9));
 						/*
 						 * Validations
 						 */
-						message = validateRetentionTime(referenceIdentifier, positionStart, positionStop);
+						message = validateRetentionTime(positionRelativePeakName, positionStart, positionStop);
 						if(message == null) {
 							if(name.isEmpty()) {
 								message = "A substance name needs to be set.";
@@ -107,9 +107,9 @@ public class PeakIdentifierValidator extends AbstractTemplateValidator implement
 		setting.setCasNumber(casNumber);
 		setting.setComments(comments);
 		setting.setContributor(contributor);
-		setting.setReference(reference);
-		setting.setTraces(traces);
 		setting.setReferenceIdentifier(referenceIdentifier);
+		setting.setTraces(traces);
+		setting.setPositionRelativePeakName(positionRelativePeakName);
 		setting.setPositionDirective(positionDirective);
 
 		return setting;

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/IdentifierSetting_1_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/IdentifierSetting_1_Test.java
@@ -59,7 +59,7 @@ public class IdentifierSetting_1_Test {
 	@Test
 	public void test7() {
 
-		assertEquals("", setting.getReference());
+		assertEquals("", setting.getReferenceIdentifier());
 	}
 
 	@Test
@@ -71,7 +71,7 @@ public class IdentifierSetting_1_Test {
 	@Test
 	public void test9() {
 
-		assertEquals("", setting.getReferenceIdentifier());
+		assertEquals("", setting.getPositionRelativePeakName());
 	}
 
 	@Test

--- a/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/IdentifierSetting_2_Test.java
+++ b/openchrom/tests/net.openchrom.xxd.process.supplier.templates.fragment.test/src/net/openchrom/xxd/process/supplier/templates/model/IdentifierSetting_2_Test.java
@@ -65,8 +65,8 @@ public class IdentifierSetting_2_Test {
 	@Test
 	public void test7() {
 
-		setting.setReference("REF-7");
-		assertEquals("REF-7", setting.getReference());
+		setting.setReferenceIdentifier("REF-7");
+		assertEquals("REF-7", setting.getReferenceIdentifier());
 	}
 
 	@Test
@@ -79,8 +79,8 @@ public class IdentifierSetting_2_Test {
 	@Test
 	public void test9() {
 
-		setting.setReferenceIdentifier("Styrene");
-		assertEquals("Styrene", setting.getReferenceIdentifier());
+		setting.setPositionRelativePeakName("Styrene");
+		assertEquals("Styrene", setting.getPositionRelativePeakName());
 	}
 
 	@Test


### PR DESCRIPTION
Initially, the value was called `ReferenceIdentifier` to allow a relative retention time/index to a given peak by name. But `ReferenceIdentifier` is also a field in `ILibraryInformation`, hence the variable in the `IdentifierSetting` was called `Reference` as the other was already used. My mistake and I tapped recently into it using the wrong fields. Hence, clean it up and use a more specific variable name, so that `ReferenceIdentifier`  belongs to  `ILibraryInformation` also in the  `IdentifierSetting` class.