### PR TITLE
Fix Peak Detector UI chart not updating when manually verifying targets

### DIFF
--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/peaks/ExtendedTargetsUI.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/peaks/ExtendedTargetsUI.java
@@ -482,8 +482,8 @@ public class ExtendedTargetsUI extends Composite implements IExtendedPartUI {
 			Iterator<?> iterator = targetListControl.get().getStructuredSelection().iterator();
 			while(iterator.hasNext()) {
 				Object object = iterator.next();
-				if(object instanceof IIdentificationTarget) {
-					deleteTarget((ITarget)object);
+				if(object instanceof ITarget target) {
+					deleteTarget(target);
 				}
 			}
 
@@ -494,8 +494,7 @@ public class ExtendedTargetsUI extends Composite implements IExtendedPartUI {
 
 	private void deleteTarget(ITarget target) {
 
-		if(peak instanceof ITargetSupplier) {
-			ITargetSupplier targetSupplier = peak;
+		if(peak instanceof ITargetSupplier targetSupplier) {
 			targetSupplier.getTargets().remove(target);
 		}
 	}

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/peaks/ExtendedTargetsUI.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/peaks/ExtendedTargetsUI.java
@@ -33,6 +33,7 @@ import org.eclipse.chemclipse.support.ui.menu.ITableMenuEntry;
 import org.eclipse.chemclipse.support.ui.swt.ExtendedTableViewer;
 import org.eclipse.chemclipse.support.ui.swt.ITableSettings;
 import org.eclipse.chemclipse.support.ui.updates.IUpdateListenerUI;
+import org.eclipse.chemclipse.support.updates.IUpdateListener;
 import org.eclipse.chemclipse.swt.ui.components.ISearchListener;
 import org.eclipse.chemclipse.swt.ui.components.SearchSupportUI;
 import org.eclipse.chemclipse.swt.ui.services.IScanIdentifierService;
@@ -249,6 +250,16 @@ public class ExtendedTargetsUI extends Composite implements IExtendedPartUI {
 
 				updateButtons();
 				fireUpdate(false);
+			}
+		});
+
+		targetListUI.setUpdateListener(new IUpdateListener() {
+
+			@Override
+			public void update() {
+
+				updateInput();
+				fireUpdate(true);
 			}
 		});
 		/*


### PR DESCRIPTION
It already had an impact and changed the peak. The change was just not displayed in the Review Peaks window, which is irritating.