### PR TITLE
Update sqlite-jdbc to 3.51.1.0

### DIFF
--- a/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
+++ b/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
@@ -57,7 +57,7 @@
 			<dependency>
 				<groupId>org.xerial</groupId>
 				<artifactId>sqlite-jdbc</artifactId>
-				<version>3.40.0.0</version>
+				<version>3.51.1.0</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
Version 3.40.0.0 used is directly vulnerable to
https://www.cve.org/CVERecord?id=CVE-2023-32697 and transitively to https://www.cve.org/CVERecord?id=CVE-2023-6378 as noted at https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc/3.40.0.0