### PR TITLE
Update woodstox-core to 6.7.0

### DIFF
--- a/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
+++ b/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
@@ -77,7 +77,7 @@
 			<dependency>
 				<groupId>org.codehaus.woodstox</groupId>
 				<artifactId>stax2-api</artifactId>
-				<version>4.2.1</version>
+				<version>4.2.2</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -87,7 +87,7 @@
 			<dependency>
 				<groupId>com.fasterxml.woodstox</groupId>
 				<artifactId>woodstox-core</artifactId>
-				<version>6.2.7</version>
+				<version>6.7.0</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
Version 6.2.7 used is vulnerable to
https://www.cve.org/CVERecord?id=CVE-2022-40152 as can be seen at https://mvnrepository.com/artifact/com.fasterxml.woodstox/woodstox-core/6.2.7 
Updated stax2-api to match the requirements upstream.