### PR TITLE
Prioritize CDK for molecule images

### DIFF
--- a/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/OSGI-INF/net.openchrom.xxd.identifier.supplier.cdk.ui.services.MoleculeImageService.xml
+++ b/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/OSGI-INF/net.openchrom.xxd.identifier.supplier.cdk.ui.services.MoleculeImageService.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="start" configuration-policy="optional" name="net.openchrom.xxd.identifier.supplier.cdk.ui.services.MoleculeImageService">
+   <property name="service.ranking" type="Integer" value="1000"/>
    <service>
       <provide interface="org.eclipse.chemclipse.swt.ui.services.IMoleculeImageService"/>
    </service>

--- a/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/src/net/openchrom/xxd/identifier/supplier/cdk/ui/services/MoleculeImageService.java
+++ b/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/src/net/openchrom/xxd/identifier/supplier/cdk/ui/services/MoleculeImageService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,7 +33,7 @@ import net.openchrom.xxd.identifier.supplier.cdk.ui.Activator;
 import net.openchrom.xxd.identifier.supplier.cdk.ui.converter.ImageConverter;
 import net.openchrom.xxd.identifier.supplier.cdk.ui.preferences.PreferencePage;
 
-@Component(service = {IMoleculeImageService.class}, configurationPolicy = ConfigurationPolicy.OPTIONAL)
+@Component(service = {IMoleculeImageService.class}, configurationPolicy = ConfigurationPolicy.OPTIONAL, property = {"service.ranking:Integer=1000"})
 public class MoleculeImageService implements IMoleculeImageService {
 
 	private static final Logger logger = Logger.getLogger(MoleculeImageService.class);


### PR DESCRIPTION
All the others that I introduced afterward are actually inferior because they rely on web services or because their rendering looks worse, like JMol, which is actually designed for 3D molecules. This requires https://github.com/eclipse-chemclipse/chemclipse/pull/2643 to work.