### PR TITLE
Allow empty user settings for Peak Review

### DIFF
--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/core/AbstractPeakReview.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/core/AbstractPeakReview.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -76,16 +76,24 @@ public abstract class AbstractPeakReview extends AbstractPeakIdentifier implemen
 					peakType = PeakType.CB;
 					break;
 				case VV:
-				default:
 					peakType = PeakType.VV;
 					break;
+				default:
+					peakType = PeakType.DEFAULT;
+					break;
 			}
-			PreferenceSupplier.setReviewPeakType(peakType);
+			if(peakType != PeakType.DEFAULT) {
+				PreferenceSupplier.setReviewPeakType(peakType);
+			}
 			/*
 			 * Peak Review Delta
 			 */
-			PreferenceSupplier.setReviewDeltaLeftMilliseconds(settings.getReviewDeltaLeft());
-			PreferenceSupplier.setReviewDeltaRightMilliseconds(settings.getReviewDeltaRight());
+			if(settings.getReviewDeltaLeft() > 0) {
+				PreferenceSupplier.setReviewDeltaLeftMilliseconds(settings.getReviewDeltaLeft());
+			}
+			if(settings.getReviewDeltaRight() > 0) {
+				PreferenceSupplier.setReviewDeltaRightMilliseconds(settings.getReviewDeltaRight());
+			}
 		}
 	}
 

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/model/DetectorType.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/model/DetectorType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Lablicate GmbH.
+ * Copyright (c) 2020, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,8 @@ public enum DetectorType implements ILabel {
 	VV("VV (Valley)"), //
 	BB("BB (Baseline)"), //
 	CB("CB (Chromatogram Baseline)"), //
-	MM("MM (Manual)");
+	MM("MM (Manual)"), //
+	DEFAULT("");
 
 	private String label = "";
 
@@ -29,6 +30,7 @@ public enum DetectorType implements ILabel {
 		this.label = label;
 	}
 
+	@Override
 	public String label() {
 
 		return label;
@@ -47,8 +49,10 @@ public enum DetectorType implements ILabel {
 			return PeakType.MM;
 		} else if(DetectorType.CB.equals(detectorType)) {
 			return PeakType.CB;
-		} else {
+		} else if(DetectorType.VV.equals(detectorType)) {
 			return PeakType.VV;
+		} else {
+			return PeakType.DEFAULT;
 		}
 	}
 }

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/settings/PeakReviewDirectSettings.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates/src/net/openchrom/xxd/process/supplier/templates/settings/PeakReviewDirectSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Lablicate GmbH.
+ * Copyright (c) 2025, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,17 +26,19 @@ import net.openchrom.xxd.process.supplier.templates.preferences.PreferenceSuppli
 
 public class PeakReviewDirectSettings extends AbstractProcessSettings implements IPeakIdentifierSettingsMSD, IPeakIdentifierSettingsCSD, IPeakIdentifierSettingsWSD {
 
-	@JsonProperty(value = "Detector Type", defaultValue = "VV")
+	@JsonProperty(value = "Detector Type", defaultValue = "")
 	@JsonPropertyDescription(value = "Select the default detector type.")
-	private DetectorType detectorType = DetectorType.VV;
-	@JsonProperty(value = "Delta Left [ms]", defaultValue = "5000")
+	private DetectorType detectorType = DetectorType.DEFAULT;
+
+	@JsonProperty(value = "Delta Left [ms]", defaultValue = "")
 	@JsonPropertyDescription(value = "Additionally display milliseconds left of the peak.")
 	@IntSettingsProperty(minValue = PreferenceSupplier.MIN_DELTA_MILLISECONDS, maxValue = PreferenceSupplier.MAX_DELTA_MILLISECONDS)
-	private int reviewDeltaLeft = 5000;
-	@JsonProperty(value = "Delta Right [ms]", defaultValue = "5000")
+	private int reviewDeltaLeft = 0;
+
+	@JsonProperty(value = "Delta Right [ms]", defaultValue = "")
 	@JsonPropertyDescription(value = "Additionally display milliseconds right of the peak.")
 	@IntSettingsProperty(minValue = PreferenceSupplier.MIN_DELTA_MILLISECONDS, maxValue = PreferenceSupplier.MAX_DELTA_MILLISECONDS)
-	private int reviewDeltaRight = 5000;
+	private int reviewDeltaRight = 0;
 
 	public DetectorType getDetectorType() {
 


### PR DESCRIPTION
The problem with https://github.com/OpenChrom/openchrom/issues/706 is if this used in batch mode and adjusted within the preferences dialog, it will reset to the user settings every next chromatogram which is annoying for users, especially as these millisecond values are difficult to guess without a preview of the peaks and its surroundings. So it is essentially user and system settings clashing. As there is an argument for both here, I allow the user settings to stay empty so it will then use the system settings as a workaround.