### PR TITLE
Remove the limits for XML

### DIFF
--- a/openchrom/pom.xml
+++ b/openchrom/pom.xml
@@ -116,16 +116,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>${tycho.groupid}</groupId>
-				<artifactId>tycho-surefire-plugin</artifactId>
-				<version>${tycho.version}</version>
-				<configuration>
-					<excludes>
-						<exclude>**/*TestCase.java</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>${maven.groupid}</groupId>
 				<artifactId>maven-install-plugin</artifactId>
 				<version>${maven-install-plugin.version}</version>
@@ -223,6 +213,17 @@
 						<skipArchive>true</skipArchive>
 					</configuration>
 				</plugin>
+				<plugin>
+				<groupId>${tycho.groupid}</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<configuration>
+					<excludes>
+						<exclude>**/*TestCase.java</exclude>
+					</excludes>
+					<argLine>-Djdk.xml.entityExpansionLimit=0 -Djdk.xml.totalEntitySizeLimit=0 -Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.maxParameterEntitySizeLimit=0</argLine>
+				</configuration>
+			</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>

--- a/openchrom/products/net.openchrom.rcp.compilation.community.product/openchrom.compilation.community.product
+++ b/openchrom/products/net.openchrom.rcp.compilation.community.product/openchrom.compilation.community.product
@@ -25,6 +25,10 @@
 -Dosgi.user.area=@user.home/.openchrom
 -Dorg.eclipse.update.reconcile=false
 -Dorg.eclipse.help.webapp.experimental.ui=true
+-Djdk.xml.entityExpansionLimit=0
+-Djdk.xml.totalEntitySizeLimit=0
+-Djdk.xml.maxGeneralEntitySizeLimit=0
+-Djdk.xml.maxParameterEntitySizeLimit=0
 -Dp2.trustedAuthorities=https://converter.openchrom.net,https://plugins.openchrom.net,https://update.openchrom.net,https://plugins.lablicate.com
 -XX:+UseG1GC
 -XX:+UseStringDeduplication


### PR DESCRIPTION
Relevant docs are:
* https://www.oracle.com/java/technologies/javase/23all-relnotes.html#JDK-8330542
* https://bugs.openjdk.org/browse/JDK-8343022

Long story short - in Java 23 stricter limits for xml were introduced as a template which became default in Java 24.
As the data to be loaded is supposedly very big - remove the limits.