### PR TITLE
Update Nebula to 3.3

### DIFF
--- a/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
+++ b/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
@@ -38,11 +38,6 @@
 		<unit id="org.apache.poi.ooxml.schemas"/>
 		<unit id="org.apache.xmlbeans"/>
 	</location>
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/nebula/updates/release/3.2.0/"/>
-		<unit id="org.eclipse.nebula.feature.feature.group"/>
-		<unit id="org.eclipse.nebula.widgets.richtext.feature.feature.group"/>
-	</location>
 	<location includeDependencyDepth="none" includeDependencyScopes="compile" missingManifest="generate" type="Maven">
 		<dependencies>
 			<dependency>

--- a/openchrom/sites/openchrom/category.xml
+++ b/openchrom/sites/openchrom/category.xml
@@ -10,6 +10,6 @@
    </category-def>
    <repository-reference location="https://download.eclipse.org/releases/2025-12/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-12" enabled="true" />
-   <repository-reference location="https://download.eclipse.org/nebula/updates/release/3.2.0/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/nebula/updates/release/3.3.0/" enabled="true" />
    <repository-reference location="https://bundles.openchrom.net/3rdparty" enabled="true" />
 </site>


### PR DESCRIPTION
Update the references in the category.xml.
Drop the nebula section from targetplatform - planner will figure the dependency directly as chemclipse already depends on it.