### PR TITLE
Add an optional file path to the CSV report

### DIFF
--- a/openchrom/plugins/net.openchrom.chromatogram.xxd.report.supplier.csv/src/net/openchrom/chromatogram/xxd/report/supplier/csv/io/ConfigurableReportWriter.java
+++ b/openchrom/plugins/net.openchrom.chromatogram.xxd.report.supplier.csv/src/net/openchrom/chromatogram/xxd/report/supplier/csv/io/ConfigurableReportWriter.java
@@ -112,6 +112,9 @@ public class ConfigurableReportWriter {
 				if(reportColumn.equals(ReportColumns.CHROMATOGRAM_NAME)) {
 					records.add(chromatogram.getName());
 				}
+				if(reportColumn.equals(ReportColumns.FILE_PATH)) {
+					records.add(chromatogram.getFile());
+				}
 				Map<String, String> headerMap = chromatogram.getHeaderDataMap();
 				for(Entry<String, String> header : headerMap.entrySet()) {
 					if(reportColumn.equals(header.getKey())) {

--- a/openchrom/plugins/net.openchrom.chromatogram.xxd.report.supplier.csv/src/net/openchrom/chromatogram/xxd/report/supplier/csv/model/ReportColumns.java
+++ b/openchrom/plugins/net.openchrom.chromatogram.xxd.report.supplier.csv/src/net/openchrom/chromatogram/xxd/report/supplier/csv/model/ReportColumns.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Lablicate GmbH.
+ * Copyright (c) 2022, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,7 @@ public class ReportColumns extends ArrayList<String> {
 	private static final long serialVersionUID = 727322817550120355L;
 
 	public static final String CHROMATOGRAM_NAME = "Chromatogram Name";
+	public static final String FILE_PATH = "File Path";
 	public static final String NUMBER_PEAKS = "Number Peaks";
 	public static final String PEAK_NUMBER = "Peak Number";
 	public static final String RETENTION_TIME = "Retention Time";
@@ -88,6 +89,7 @@ public class ReportColumns extends ArrayList<String> {
 		ReportColumns reportColumns = new ReportColumns();
 
 		reportColumns.add(CHROMATOGRAM_NAME);
+		reportColumns.add(FILE_PATH);
 		reportColumns.add(NUMBER_PEAKS);
 		reportColumns.add(PEAK_NUMBER);
 		reportColumns.add(RETENTION_TIME);


### PR DESCRIPTION
If this gets exported into the laboratory information management system, it is convenient to be able to link the original raw data file, which is usually stored outside the LIMS. It allows for quick access and is also required to keep an audit trail for compliant data storage.