### PR TITLE
Fix warning "Parameter 'overwrite' is deprecated: Use changeDetection instead."

### DIFF
--- a/openchrom/pom.xml
+++ b/openchrom/pom.xml
@@ -132,7 +132,7 @@
 						<phase>prepare-package</phase>
 						<configuration>
 							<outputDirectory>${project.build.directory}</outputDirectory>
-							<overwrite>true</overwrite>
+							<changeDetection>always</changeDetection>
 							<resources>
 								<resource>
 									<directory>${basedir}</directory>


### PR DESCRIPTION
Followup to https://github.com/OpenChrom/openchrom/pull/795 See https://maven.apache.org/plugins/maven-resources-plugin/copy-resources-mojo.html#changeDetection