### PR TITLE
Don't round ions in NetCDF imports

### DIFF
--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.cdf.ui/src/net/openchrom/msd/converter/supplier/cdf/ui/preferences/PreferencePage.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.cdf.ui/src/net/openchrom/msd/converter/supplier/cdf/ui/preferences/PreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,8 +13,6 @@
 package net.openchrom.msd.converter.supplier.cdf.ui.preferences;
 
 import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.ExtendedIntegerFieldEditor;
-import org.eclipse.chemclipse.support.ui.preferences.fieldeditors.SpinnerFieldEditor;
-import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
@@ -39,8 +37,6 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	@Override
 	protected void createFieldEditors() {
 
-		addField(new SpinnerFieldEditor(PreferenceSupplier.P_PRECISION, "Precision Ions", PreferenceSupplier.MIN_PRECISION, PreferenceSupplier.MAX_PRECISION, getFieldEditorParent()));
-		addField(new BooleanFieldEditor(PreferenceSupplier.P_FORCE_PARSE_NOMINAL, "Force Parse Nominal", getFieldEditorParent()));
 		addField(new ExtendedIntegerFieldEditor(PreferenceSupplier.P_MODULATION_TIME_2D, "Modulation Time (GCxGC) [ms]", PreferenceSupplier.MIN_MODULATION_TIME, PreferenceSupplier.MAX_MODULATION_TIME, getFieldEditorParent()));
 	}
 }

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.cdf/src/net/openchrom/msd/converter/supplier/cdf/io/ChromatogramReaderMSD.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.cdf/src/net/openchrom/msd/converter/supplier/cdf/io/ChromatogramReaderMSD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,7 +39,6 @@ import net.openchrom.msd.converter.supplier.cdf.io.support.IAbstractCDFChromatog
 import net.openchrom.msd.converter.supplier.cdf.model.VendorChromatogram;
 import net.openchrom.msd.converter.supplier.cdf.model.VendorIon;
 import net.openchrom.msd.converter.supplier.cdf.model.VendorScan;
-import net.openchrom.msd.converter.supplier.cdf.preferences.PreferenceSupplier;
 
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.NetcdfFiles;
@@ -121,13 +120,10 @@ public class ChromatogramReaderMSD extends AbstractChromatogramMSDReader impleme
 		chromatogram = new VendorChromatogram();
 		setChromatogramEntries(chromatogram, in, file);
 
-		int precision = PreferenceSupplier.getPrecision();
-		boolean forceParseNominal = PreferenceSupplier.isForceParseNominal();
-
 		monitor.beginTask(ConverterMessages.importScan, in.getNumberOfScans());
 		for(int i = 1; i <= in.getNumberOfScans(); i++) {
 			try {
-				massSpectrum = in.getMassSpectrum(i, precision, forceParseNominal);
+				massSpectrum = in.getMassSpectrum(i);
 				chromatogram.addScan(massSpectrum);
 			} catch(NoSuchScanStored e) {
 				logger.warn(e);

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.cdf/src/net/openchrom/msd/converter/supplier/cdf/io/support/CDFChromtogramArrayReader.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.cdf/src/net/openchrom/msd/converter/supplier/cdf/io/support/CDFChromtogramArrayReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,10 +13,6 @@
 package net.openchrom.msd.converter.supplier.cdf.io.support;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.eclipse.chemclipse.msd.model.core.AbstractIon;
 
 import net.openchrom.msd.converter.supplier.cdf.exceptions.NoCDFVariableDataFound;
 import net.openchrom.msd.converter.supplier.cdf.exceptions.NoSuchScanStored;
@@ -41,10 +37,10 @@ public class CDFChromtogramArrayReader extends AbstractCDFChromatogramArrayReade
 	public CDFChromtogramArrayReader(NetcdfFile chromatogram) throws IOException, NoCDFVariableDataFound, NotEnoughScanDataStored {
 
 		super(chromatogram);
-		initializeVariables();
+		initializeScanVariables();
 	}
 
-	private void initializeVariables() throws IOException, NoCDFVariableDataFound {
+	private void initializeScanVariables() throws IOException, NoCDFVariableDataFound {
 
 		String variable;
 		variable = CDFConstants.VARIABLE_MASS_VALUES;
@@ -79,7 +75,7 @@ public class CDFChromtogramArrayReader extends AbstractCDFChromatogramArrayReade
 		valueArrayScanIndex = (int[])valuesScanIndex.read().get1DJavaArray(DataType.INT);
 	}
 
-	public VendorScan getMassSpectrum(int scan, int precision, boolean forceNominal) throws NoSuchScanStored {
+	public VendorScan getMassSpectrum(int scan) throws NoSuchScanStored {
 
 		/*
 		 * If the scan is out of a valid range.
@@ -91,7 +87,6 @@ public class CDFChromtogramArrayReader extends AbstractCDFChromatogramArrayReade
 		 * Scan
 		 */
 		VendorScan massSpectrum = new VendorScan();
-		Map<Integer, DataPoint> dataPointMap = (forceNominal) ? new HashMap<>() : null;
 		/*
 		 * --scan because the index of the array starts at 0 and not at 1.
 		 */
@@ -101,45 +96,15 @@ public class CDFChromtogramArrayReader extends AbstractCDFChromatogramArrayReade
 
 		for(int i = 0; i < peaks; i++) {
 			int position = offset + i;
-			/*
-			 * If force nominal, then first collect and condense the data.
-			 */
-			if(forceNominal) {
-				int mz = AbstractIon.getIon(valueArrayIon[position]);
-				float intensity = valueArrayAbundance[position];
 
-				if(intensity > 0) {
-					DataPoint dataPoint = dataPointMap.get(mz);
-					if(dataPoint == null) {
-						dataPoint = new DataPoint(mz, intensity);
-						dataPointMap.put(mz, dataPoint);
-					} else {
-						double abundance = dataPoint.getIntensity() + intensity;
-						dataPoint.setIntensity(abundance);
-					}
-				}
-			} else {
-				/*
-				 * Normal
-				 */
-				double mz = AbstractIon.getIon(valueArrayIon[position], precision);
-				float intensity = valueArrayAbundance[position];
+			double mz = valueArrayIon[position];
+			float intensity = valueArrayAbundance[position];
 
-				if(intensity > 0) {
-					addIon(massSpectrum, mz, intensity);
-				}
-			}
-		}
-		/*
-		 * Add the collected and condensed data.
-		 */
-		if(forceNominal) {
-			for(DataPoint dataPoint : dataPointMap.values()) {
-				double mz = dataPoint.getMz();
-				float intensity = (float)dataPoint.getIntensity();
+			if(intensity > 0) {
 				addIon(massSpectrum, mz, intensity);
 			}
 		}
+
 		/*
 		 * ++scan because it was decremented before
 		 */

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.cdf/src/net/openchrom/msd/converter/supplier/cdf/preferences/PreferenceSupplier.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.cdf/src/net/openchrom/msd/converter/supplier/cdf/preferences/PreferenceSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 Lablicate GmbH.
+ * Copyright (c) 2013, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,17 +18,8 @@ import org.osgi.framework.FrameworkUtil;
 
 public class PreferenceSupplier extends AbstractPreferenceSupplier implements IPreferenceSupplier {
 
-	public static final String P_PRECISION = "precision";
-	public static final int DEF_PRECISION = 2;
-	public static final int MIN_PRECISION = 0;
-	public static final int MAX_PRECISION = 10;
-	public static final int PRECISION_INCEREMENT = 1;
-
 	public static final int MIN_MODULATION_TIME = 1;
 	public static final int MAX_MODULATION_TIME = Integer.MAX_VALUE;
-
-	public static final String P_FORCE_PARSE_NOMINAL = "forceParseNominal";
-	public static final boolean DEF_FORCE_PARSE_NOMINAL = false;
 
 	public static final String P_MODULATION_TIME_2D = "modulationTime2D"; // $NON-NLS-1$
 	public static final int DEF_MODULATION_TIME_2D = 10000; // Milliseconds = 10 s
@@ -47,26 +38,7 @@ public class PreferenceSupplier extends AbstractPreferenceSupplier implements IP
 	@Override
 	public void initializeDefaults() {
 
-		putDefault(P_PRECISION, Integer.toString(DEF_PRECISION));
-		putDefault(P_FORCE_PARSE_NOMINAL, Boolean.toString(DEF_FORCE_PARSE_NOMINAL));
 		putDefault(P_MODULATION_TIME_2D, Integer.toString(DEF_MODULATION_TIME_2D));
-	}
-
-	public static int getPrecision() {
-
-		int precision = INSTANCE().getInteger(P_PRECISION, DEF_PRECISION);
-		/*
-		 * Validate the precision.
-		 */
-		if(precision < MIN_PRECISION || precision > MAX_PRECISION) {
-			precision = DEF_PRECISION;
-		}
-		return precision;
-	}
-
-	public static boolean isForceParseNominal() {
-
-		return INSTANCE().getBoolean(P_FORCE_PARSE_NOMINAL, DEF_FORCE_PARSE_NOMINAL);
 	}
 
 	public static int getModulationTime2D() {


### PR DESCRIPTION
My point being that this step should be done by the nominalize unit mass filter instead.