### PR TITLE
Bump log4j to 2.25.3

### DIFF
--- a/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.core.runtime,
  wrapped.dk.brics.automaton;bundle-version="1.12.0",
  com.fasterxml.woodstox.woodstox-core;bundle-version="6.2.7",
  org.eclipse.chemclipse.chromatogram.xxd.identifier;bundle-version="0.9.0",
- javax.vecmath;bundle-version="1.5.2"
+ javax.vecmath;bundle-version="1.5.2",
+ org.apache.logging.log4j.api;bundle-version="[2.25.3,3.0.0)
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: net.openchrom.xxd.identifier.supplier.cdk.converter,
@@ -28,5 +29,4 @@ Export-Package: net.openchrom.xxd.identifier.supplier.cdk.converter,
  net.openchrom.xxd.identifier.supplier.cdk.support
 Import-Package: com.fasterxml.jackson.annotation;version="[2.20.0,3.0.0)",
  jakarta.annotation;version="2.1.1",
- org.apache.logging.log4j;version="[2.20.0,3.0.0)",
  org.codehaus.stax2;version="[4.2.0,5.0.0)"


### PR DESCRIPTION
It is already at that version in the product thanks to transitive dependencies. Require it on our side for the sake of https://nvd.nist.gov/vuln/detail/CVE-2025-68161 mitigation