### PR TITLE
Use proper shells in Handlers

### DIFF
--- a/openchrom/plugins/net.openchrom.feature.branding/src/net/openchrom/feature/branding/ContactHandler.java
+++ b/openchrom/plugins/net.openchrom.feature.branding/src/net/openchrom/feature/branding/ContactHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Lablicate GmbH.
+ * Copyright (c) 2024, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,12 +14,11 @@ package net.openchrom.feature.branding;
 
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.swt.program.Program;
-import org.eclipse.swt.widgets.Shell;
 
 public class ContactHandler {
 
 	@Execute
-	public void execute(Shell shell) {
+	public void execute() {
 
 		Program.launch("https://lablicate.com/about/contact");
 	}

--- a/openchrom/plugins/net.openchrom.installer.ui/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.installer.ui/META-INF/MANIFEST.MF
@@ -34,7 +34,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.equinox.p2.ui;bundle-version="2.8.100",
  org.eclipse.chemclipse.progress;bundle-version="0.9.0",
  net.openchrom.feature.branding;bundle-version="1.5.31",
- com.google.gson;bundle-version="2.13.2"
+ com.google.gson;bundle-version="2.13.2",
+ org.eclipse.e4.core.contexts;bundle-version="[1.13.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: net.openchrom.installer.ui

--- a/openchrom/plugins/net.openchrom.installer.ui/src/net/openchrom/installer/ui/handlers/AddonsInstallHandler.java
+++ b/openchrom/plugins/net.openchrom.installer.ui/src/net/openchrom/installer/ui/handlers/AddonsInstallHandler.java
@@ -13,9 +13,10 @@
 package net.openchrom.installer.ui.handlers;
 
 import org.eclipse.chemclipse.logging.core.Logger;
-import org.eclipse.chemclipse.support.ui.workbench.DisplayUtils;
+import org.eclipse.e4.core.contexts.Active;
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.jface.wizard.WizardDialog;
+import org.eclipse.swt.widgets.Shell;
 
 import net.openchrom.installer.ui.discovery.IPluginInstallJob;
 import net.openchrom.installer.ui.discovery.PrepareInstallProfileJob;
@@ -26,12 +27,12 @@ public class AddonsInstallHandler {
 	private static final Logger logger = Logger.getLogger(AddonsInstallHandler.class);
 
 	@Execute
-	void execute() {
+	void execute(@Active Shell shell) {
 
 		try {
 			IPluginInstallJob installJob = new PrepareInstallProfileJob();
 			PluginDiscoveryWizard wizard = new PluginDiscoveryWizard(installJob);
-			WizardDialog dialog = new WizardDialog(DisplayUtils.getShell(), wizard);
+			WizardDialog dialog = new WizardDialog(shell, wizard);
 			dialog.open();
 		} catch(IllegalArgumentException e) {
 			logger.warn(e);


### PR DESCRIPTION
Inject the "active" Shell instead of whatever DisplayUtils.getShell() guesses.
Don't pass Shell where not needed.