### PR TITLE
Don't focus error log on new event

### DIFF
--- a/openchrom/plugins/net.openchrom.rcp.compilation.community.ui/plugin_customization.ini
+++ b/openchrom/plugins/net.openchrom.rcp.compilation.community.ui/plugin_customization.ini
@@ -1,3 +1,6 @@
 org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP = true
 org.eclipse.ui/SHOW_TRADITIONAL_STYLE_TABS = false
 org.eclipse.ui/SHOW_MEMORY_MONITOR = true
+org.eclipse.ui.views.log/activate = false
+org.eclipse.ui.views.log/activateWarn = false
+org.eclipse.ui.views.log/activateError = false


### PR DESCRIPTION
You can get the previous behavior by checking the setting again:

<img width="687" height="377" alt="grafik" src="https://github.com/user-attachments/assets/ae26c9e7-e351-4c4b-8424-4fb10ab42fea" />
