### PR TITLE
Make modifications of p2 Policy a proper DS

### DIFF
--- a/openchrom/plugins/net.openchrom.installer.ui/.project
+++ b/openchrom/plugins/net.openchrom.installer.ui/.project
@@ -20,6 +20,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>

--- a/openchrom/plugins/net.openchrom.installer.ui/.settings/org.eclipse.pde.ds.annotations.prefs
+++ b/openchrom/plugins/net.openchrom.installer.ui/.settings/org.eclipse.pde.ds.annotations.prefs
@@ -1,0 +1,7 @@
+dsVersion=V1_4
+eclipse.preferences.version=1
+enabled=true
+generateBundleActivationPolicyLazy=true
+path=OSGI-INF
+validationErrorLevel=error
+validationErrorLevel.missingImplicitUnbindMethod=error

--- a/openchrom/plugins/net.openchrom.installer.ui/META-INF/MANIFEST.MF
+++ b/openchrom/plugins/net.openchrom.installer.ui/META-INF/MANIFEST.MF
@@ -36,6 +36,7 @@ Require-Bundle: org.eclipse.core.runtime,
  net.openchrom.feature.branding;bundle-version="1.6.13",
  com.google.gson;bundle-version="2.13.2",
  org.eclipse.e4.core.contexts;bundle-version="[1.13.0,2.0.0)"
+Service-Component: OSGI-INF/net.openchrom.installer.ui.OpenchromP2Policy.xml
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: net.openchrom.installer.ui

--- a/openchrom/plugins/net.openchrom.installer.ui/OSGI-INF/net.openchrom.installer.ui.OpenchromP2Policy.xml
+++ b/openchrom/plugins/net.openchrom.installer.ui/OSGI-INF/net.openchrom.installer.ui.OpenchromP2Policy.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" immediate="true" name="net.openchrom.installer.ui.OpenchromP2Policy">
+   <reference cardinality="1..1" field="policy" interface="org.eclipse.equinox.p2.ui.Policy" name="policy"/>
+   <implementation class="net.openchrom.installer.ui.OpenchromP2Policy"/>
+</scr:component>

--- a/openchrom/plugins/net.openchrom.installer.ui/src/net/openchrom/installer/ui/Activator.java
+++ b/openchrom/plugins/net.openchrom.installer.ui/src/net/openchrom/installer/ui/Activator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 Lablicate GmbH.
+ * Copyright (c) 2014, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,6 @@
 package net.openchrom.installer.ui;
 
 import org.eclipse.chemclipse.support.ui.activator.AbstractActivatorUI;
-import org.eclipse.equinox.p2.ui.Policy;
 import org.osgi.framework.BundleContext;
 
 import net.openchrom.installer.preferences.PreferenceSupplier;
@@ -32,7 +31,6 @@ public class Activator extends AbstractActivatorUI {
 		super.start(context);
 		plugin = this;
 		initializePreferenceStore(PreferenceSupplier.INSTANCE());
-		setPolicy(context);
 	}
 
 	@Override
@@ -47,10 +45,4 @@ public class Activator extends AbstractActivatorUI {
 		return plugin;
 	}
 
-	private void setPolicy(BundleContext context) {
-
-		Policy policy = context.getService(context.getServiceReference(Policy.class));
-		policy.setRepositoriesVisible(false);
-		policy.setRepositoryPreferencePageId(null);
-	}
 }

--- a/openchrom/plugins/net.openchrom.installer.ui/src/net/openchrom/installer/ui/OpenchromP2Policy.java
+++ b/openchrom/plugins/net.openchrom.installer.ui/src/net/openchrom/installer/ui/OpenchromP2Policy.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Aleksandar Kurtakov - initial API and implementation
+ *******************************************************************************/
+package net.openchrom.installer.ui;
+
+import org.eclipse.equinox.p2.ui.Policy;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(immediate = true)
+public class OpenchromP2Policy {
+
+	@Reference
+	private Policy policy;
+
+	@Activate
+	public void activate() {
+
+		policy.setRepositoriesVisible(false);
+		policy.setRepositoryPreferencePageId(null);
+	}
+}


### PR DESCRIPTION
Decouples the error prone expectation that when
net.openchrom.installer.ui bundle Activator kicks in the p2 Policy DS will be available.
By making it proper DS, changes to the policy will happen as soon as the service is available without the need for extra checks.