### PR TITLE
Add the Thermo Chromeleon SFD plug-in

### DIFF
--- a/openchrom/plugins/net.openchrom.installer.ui/plugin.xml
+++ b/openchrom/plugins/net.openchrom.installer.ui/plugin.xml
@@ -119,6 +119,19 @@
 
       <pluginDescriptor
             categoryId="com.lablicate.openchrom.converters.proprietary"
+            description="Reads *.sfd files."
+            groupId="net.openchrom.wsd.converter"
+            id="net.openchrom.wsd.converter.supplier.thermo.sfd.feature"
+            kind="converter"
+            license="Converter License Terms"
+            name="Thermo Chromeleon HPLC-DAD"
+            provider="Lablicate"
+            summary="Free extension exclusively for OpenChrom®"
+            icon="icons/32x32/Thermo.png">
+      </pluginDescriptor>
+
+      <pluginDescriptor
+            categoryId="com.lablicate.openchrom.converters.proprietary"
             description="Reads *.txt files."
             groupId="net.openchrom.csd.converter"
             id="net.openchrom.csd.converter.supplier.igraphx.feature"


### PR DESCRIPTION
SFD might stand for full spectrum data, as it contains the 3D HPLC-DAD chromatogram with full wavelengths.