### PR TITLE
Implement in-place update

### DIFF
--- a/openchrom/plugins/net.openchrom.installer.ui/fragment.e4xmi
+++ b/openchrom/plugins/net.openchrom.installer.ui/fragment.e4xmi
@@ -2,14 +2,19 @@
 <fragment:ModelFragments xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:commands="http://www.eclipse.org/ui/2010/UIModel/application/commands" xmlns:fragment="http://www.eclipse.org/ui/2010/UIModel/fragment" xmlns:menu="http://www.eclipse.org/ui/2010/UIModel/application/ui/menu" xmi:id="_71giYHzxEeOENN5Yh22WyA">
   <fragments xsi:type="fragment:StringModelFragment" xmi:id="_h37UIHzzEeOENN5Yh22WyA" featurename="commands" parentElementId="org.eclipse.chemclipse.rcp.ide.application">
     <elements xsi:type="commands:Command" xmi:id="_jzDkEHzzEeOENN5Yh22WyA" elementId="net.openchrom.installer.ui.command.install.addons" commandName="Install Add-ons"/>
+    <elements xsi:type="commands:Command" xmi:id="_rY6ywESHEfGQWeaOVqkAyA" elementId="net.openchrom.installer.ui.command.checkupdates" commandName="Check for Updates"/>
   </fragments>
   <fragments xsi:type="fragment:StringModelFragment" xmi:id="_rXXqEHzzEeOENN5Yh22WyA" featurename="handlers" parentElementId="org.eclipse.chemclipse.rcp.ide.application">
     <elements xsi:type="commands:Handler" xmi:id="_tPN8gHzzEeOENN5Yh22WyA" elementId="net.openchrom.installer.ui.handler.install.addons" contributionURI="bundleclass://net.openchrom.installer.ui/net.openchrom.installer.ui.handlers.AddonsInstallHandler" command="_jzDkEHzzEeOENN5Yh22WyA"/>
+    <elements xsi:type="commands:Handler" xmi:id="_8G1hkESHEfGQWeaOVqkAyA" elementId="net.openchrom.installer.ui.handler.checkupdates" contributionURI="bundleclass://net.openchrom.installer.ui/net.openchrom.installer.ui.handlers.CheckForUpdatesHander" command="_rY6ywESHEfGQWeaOVqkAyA"/>
   </fragments>
   <fragments xsi:type="fragment:StringModelFragment" xmi:id="_9H7hoHzzEeOENN5Yh22WyA" featurename="children" parentElementId="org.eclipse.chemclipse.rcp.app.ui.menu.plugins" positionInList="">
     <elements xsi:type="menu:HandledMenuItem" xmi:id="_DJRZAHz0EeOENN5Yh22WyA" elementId="net.openchrom.installer.ui.handledmenuitem.install.addons" label="Install Add-ons" iconURI="platform:/plugin/net.openchrom.installer.ui/icons/16x16/plugin.png" command="_jzDkEHzzEeOENN5Yh22WyA"/>
   </fragments>
   <fragments xsi:type="fragment:StringModelFragment" xmi:id="_JGPGsHz0EeOENN5Yh22WyA" featurename="children" parentElementId="org.eclipse.chemclipse.rcp.app.ui.toolbar.plugins">
     <elements xsi:type="menu:HandledToolItem" xmi:id="_NLqrAHz0EeOENN5Yh22WyA" elementId="net.openchrom.installer.ui.handledtoolitem.install.addons" label="Install Add-ons" iconURI="platform:/plugin/net.openchrom.installer.ui/icons/16x16/plugin.png" command="_jzDkEHzzEeOENN5Yh22WyA"/>
+  </fragments>
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_Nsa4MESIEfGQWeaOVqkAyA" featurename="children" parentElementId="org.eclipse.chemclipse.rcp.app.ui.menu.help">
+    <elements xsi:type="menu:HandledMenuItem" xmi:id="_FARncESIEfGQWeaOVqkAyA" elementId="net.openchrom.installer.ui.handledmenuitem.checkupdates" label="Check for Updates" iconURI="platform:/plugin/org.eclipse.chemclipse.rcp.ui.icons/icons/16x16/refresh.png" command="_rY6ywESHEfGQWeaOVqkAyA"/>
   </fragments>
 </fragment:ModelFragments>

--- a/openchrom/plugins/net.openchrom.installer.ui/src/net/openchrom/installer/ui/handlers/CheckForUpdatesHander.java
+++ b/openchrom/plugins/net.openchrom.installer.ui/src/net/openchrom/installer/ui/handlers/CheckForUpdatesHander.java
@@ -1,0 +1,190 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Aleksandar Kurtakov - initial API and implementation
+ *******************************************************************************/
+package net.openchrom.installer.ui.handlers;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.e4.core.contexts.Active;
+import org.eclipse.e4.core.di.annotations.CanExecute;
+import org.eclipse.e4.core.di.annotations.Execute;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.engine.ProvisioningContext;
+import org.eclipse.equinox.p2.operations.ProvisioningSession;
+import org.eclipse.equinox.p2.operations.UpdateOperation;
+import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
+import org.eclipse.equinox.p2.ui.ProvisioningUI;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.program.Program;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Link;
+import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Shell;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.Version;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import net.openchrom.installer.ui.model.CurrentVersion;
+
+public class CheckForUpdatesHander {
+
+	private static final String URL_STR = "https://marketplace.lablicate.com/api/download/1/current_element_version";
+
+	@Execute
+	public void execute(@Active Shell shell) {
+
+		Version bundleVersion = FrameworkUtil.getBundle(CheckForUpdatesHander.class).getVersion();
+		boolean updateAvailable = false;
+		Version availableVersion = null;
+
+		CurrentVersion latestVersion = getLatestVersion();
+		if(latestVersion != null) {
+			availableVersion = new Version(latestVersion.getVersion());
+			if(availableVersion.compareTo(bundleVersion) > 0) {
+				updateAvailable = true;
+			}
+		}
+
+		if(updateAvailable) {
+			Version toVersion = availableVersion;
+			MessageDialog dialog = new MessageDialog(shell, "Check for Updates", null, "New version available -" + toVersion.toString(), MessageDialog.INFORMATION, new String[]{"OK"}, 0) {
+
+				@Override
+				protected Control createCustomArea(Composite parent) {
+
+					boolean performUpdate = Boolean.getBoolean("openchrom.update");
+					UpdateOperation op = getUpdateOperation(toVersion);
+					if(performUpdate && canPerformUpdate(op)) {
+						Link link = new Link(parent, SWT.NONE);
+						link.setText("Experimental: <a href=\"https://openchrom.net/download\">Perform Update</a>");
+						link.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
+							this.close();
+							ProvisioningUI.getDefaultUI().openUpdateWizard(false, op, null);
+						}));
+						return link;
+					} else {
+						Link link = new Link(parent, SWT.NONE);
+						link.setText("Download from <a href=\"https://openchrom.net/download\">https://openchrom.net/download</a>");
+						link.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> Program.launch(e.text)));
+						return link;
+					}
+				}
+			};
+			dialog.open();
+		} else {
+			MessageBox box = new MessageBox(shell);
+			box.setText("Check for Updates");
+			box.setMessage("No new version available!");
+			box.open();
+		}
+
+	}
+
+	private CurrentVersion getLatestVersion() {
+
+		try (HttpClient client = HttpClient.newHttpClient()) {
+			HttpRequest request = HttpRequest.newBuilder().uri(URI.create(URL_STR)).GET().build();
+			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+			Gson gson = new Gson();
+			JsonObject data = JsonParser.parseString(response.body()).getAsJsonObject().getAsJsonObject("data");
+			return gson.fromJson(data, CurrentVersion.class);
+		} catch(IOException | InterruptedException e) {
+			// can't determine latest version
+		}
+		return null;
+	}
+
+	private boolean canPerformUpdate(UpdateOperation op) {
+
+		IStatus status = op.resolveModal(new NullProgressMonitor());
+		if(status.isOK() && op.getPossibleUpdates().length > 0) {
+			return true;
+		}
+		return false;
+	}
+
+	private UpdateOperation getUpdateOperation(Version toVersion) {
+
+		IProvisioningAgent agent = getProvisioningAgent();
+
+		URI[] newUris = updateP2Repos(agent, toVersion);
+
+		ProvisioningSession session = new ProvisioningSession(agent);
+
+		// Update everything in the running profile
+		UpdateOperation op = new UpdateOperation(session);
+
+		ProvisioningContext ctx = op.getProvisioningContext();
+
+		// Force p2 to use ONLY the rewritten repositories
+		ctx.setMetadataRepositories(newUris);
+		ctx.setArtifactRepositories(newUris);
+		return op;
+	}
+
+	private URI[] updateP2Repos(IProvisioningAgent agent, Version toVersion) {
+
+		IMetadataRepositoryManager metaManager = agent.getService(IMetadataRepositoryManager.class);
+
+		URI[] known = metaManager.getKnownRepositories(IMetadataRepositoryManager.REPOSITORIES_ALL);
+		Set<URI> newUris = new HashSet<>();
+		for(URI uri : known) {
+			URI newUri = replaceVersion(uri, toVersion.toString());
+			newUris.add(newUri);
+		}
+		return newUris.toArray(URI[]::new);
+	}
+
+	private static URI replaceVersion(URI uri, String newVersion) {
+
+		String path = uri.getPath();
+		if(path.endsWith("/")) {
+			path = path.substring(0, path.length() - 1);
+		}
+
+		int i = path.lastIndexOf('/');
+		String newPath = path.substring(0, i + 1) + newVersion;
+
+		return uri.resolve(newPath);
+	}
+
+	private IProvisioningAgent getProvisioningAgent() {
+
+		// Get from service registry
+		BundleContext context = FrameworkUtil.getBundle(this.getClass()).getBundleContext();
+		ServiceReference<IProvisioningAgent> sr = context.getServiceReference(IProvisioningAgent.class);
+		return context.getService(sr);
+	}
+
+	@CanExecute
+	public boolean canExecute() {
+
+		return true;
+	}
+
+}

--- a/openchrom/plugins/net.openchrom.installer.ui/src/net/openchrom/installer/ui/model/CurrentVersion.java
+++ b/openchrom/plugins/net.openchrom.installer.ui/src/net/openchrom/installer/ui/model/CurrentVersion.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Aleksandar Kurtakov - initial API and implementation
+ *******************************************************************************/
+package net.openchrom.installer.ui.model;
+
+import com.google.gson.JsonObject;
+
+public class CurrentVersion {
+
+	private String version;
+	private String createdAt;
+
+	public CurrentVersion(JsonObject data) {
+
+		version = data.get("version").getAsString();
+		createdAt = data.get("created_at").getAsString();
+	}
+
+	public String getVersion() {
+
+		return version;
+	}
+
+	public String getCreatedAt() {
+
+		return createdAt;
+	}
+}


### PR DESCRIPTION
There is new `-Dopenchrom.update=true` JVM parameter that controls whether inplace update is enabled. This will have to stay (probably with flipped default) so there is a way to disable update for snap/flatpak/etc. When updates are enabled the following happens:
* all currently configured p2 repo uris are fetched from p2
* all the uris get there last segment (aka version) replaced with the last one that marketplace gives
* UpdateOperation with the new uris is created and resolved
* if resolved operation is successful and there are proposed updates a link to perform the update using p2 UI is created in the dialog instead of the download one.