### PR TITLE
Fix mvn build error

### DIFF
--- a/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/src/net/openchrom/xxd/identifier/supplier/cdk/ui/converter/ImageConverter.java
+++ b/openchrom/plugins/net.openchrom.xxd.identifier.supplier.cdk.ui/src/net/openchrom/xxd/identifier/supplier/cdk/ui/converter/ImageConverter.java
@@ -107,7 +107,7 @@ public class ImageConverter {
 				.withZoom(2.0) //
 				.withBackgroundColor(TRANSPARENT); //
 
-		if(PreferencesSupport.isDarkTheme()) {
+		if(Display.getCurrent() != null && PreferencesSupport.isDarkTheme()) {
 			if(PreferenceSupplier.isColorAtoms()) {
 				depictionGenerator = depictionGenerator.withParam(StandardGenerator.AtomColor.class, new IAtomColorer() {
 


### PR DESCRIPTION
Fixes building error when building via terminal

```
-------------------------------------------------------------------------------
Test set: net.openchrom.xxd.identifier.supplier.cdk.converter.MoleculeImage_Test
-------------------------------------------------------------------------------
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.679 s <<< FAILURE! -- in net.openchrom.xxd.identifier.supplier.cdk.converter.MoleculeImage_Test
net.openchrom.xxd.identifier.supplier.cdk.converter.MoleculeImage_Test.testAspirin -- Time elapsed: 0.678 s <<< ERROR!
org.eclipse.swt.SWTException: Invalid thread access
	at org.eclipse.swt.SWT.error(SWT.java:4950)
	at org.eclipse.swt.SWT.error(SWT.java:4865)
	at org.eclipse.swt.SWT.error(SWT.java:4836)
	at org.eclipse.swt.widgets.Display.error(Display.java:1211)
	at org.eclipse.swt.widgets.Display.createDisplay(Display.java:962)
	at org.eclipse.swt.widgets.Display.create(Display.java:946)
	at org.eclipse.swt.graphics.Device.<init>(Device.java:132)
	at org.eclipse.swt.widgets.Display.<init>(Display.java:800)
	at org.eclipse.swt.widgets.Display.<init>(Display.java:791)
	at org.eclipse.swt.widgets.Display.getDefault(Display.java:1545)
	at org.eclipse.chemclipse.support.ui.workbench.PreferencesSupport.isDarkTheme(PreferencesSupport.java:46)
	at net.openchrom.xxd.identifier.supplier.cdk.ui.converter.ImageConverter.createImage(ImageConverter.java:110)
	at net.openchrom.xxd.identifier.supplier.cdk.ui.converter.ImageConverter.smilesToImage(ImageConverter.java:63)
	at net.openchrom.xxd.identifier.supplier.cdk.converter.MoleculeImage_Test.testAspirin(MoleculeImage_Test.java:31)

```