### PR TITLE
Switch to a faster CDN for Eclipse downloads

### DIFF
--- a/openchrom/pom.xml
+++ b/openchrom/pom.xml
@@ -36,7 +36,7 @@
 	<repositories>
 		<repository>
 			<id>jre-updates</id>
-			<url>https://download.eclipse.org/justj/jres/21/updates/release/latest/</url>
+			<url>https://mirror.lablicate.com/eclipse/justj/jres/21/updates/release/latest/</url>
 			<layout>p2</layout>
 		</repository>
 	</repositories>

--- a/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
+++ b/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
@@ -3,7 +3,7 @@
 <target name="OpenChrom" sequenceNumber="43">
 <locations>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/releases/2026-03/"/>
+		<repository location="https://mirror.lablicate.com/eclipse/releases/2026-03/"/>
 		<unit id="org.eclipse.equinox.sdk.feature.group"/>
 		<unit id="org.eclipse.platform.feature.group"/>
 		<unit id="org.eclipse.jdt.junit6.runtime"/>
@@ -13,7 +13,7 @@
 		<unit id="org.apache.aries.spifly.dynamic.bundle"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/cbi/updates/license/"/>
+		<repository location="https://mirror.lablicate.com/eclipse/cbi/updates/license/"/>
 		<unit id="org.eclipse.license.feature.group"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -31,7 +31,7 @@
 		<unit id="net.openchrom.thirdparty.inchi.feature.feature.group"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-03"/>
+		<repository location="https://mirror.lablicate.com/eclipse/tools/orbit/simrel/orbit-aggregation/2026-03"/>
 		<unit id="org.apache.commons.commons-csv"/>
 		<unit id="org.apache.poi"/>
 		<unit id="org.apache.poi.ooxml"/>

--- a/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
+++ b/openchrom/releng/net.openchrom.targetplatform/net.openchrom.targetplatform.target
@@ -21,7 +21,7 @@
 		<repository location="https://download.eclipse.org/swtchart/integration/develop/repository"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/chemclipse/integration/develop/repository/"/>
+		<repository location="https://download.chemclipse.net/integration/repository/"/>
 		<unit id="org.eclipse.chemclipse.rcp.compilation.community.feature.feature.group"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
@Lablicate will sponsor a fast download link, while the @eclipse-foundation currently struggles with https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/7469 for quite some time now.