### PR TITLE
Add Thermo Chromeleon .cmbx support

### DIFF
--- a/openchrom/plugins/net.openchrom.installer.ui/plugin.xml
+++ b/openchrom/plugins/net.openchrom.installer.ui/plugin.xml
@@ -132,6 +132,19 @@
 
       <pluginDescriptor
             categoryId="com.lablicate.openchrom.converters.proprietary"
+            description="Reads *.cmbx files."
+            groupId="net.openchrom.xxd.converter"
+            id="net.openchrom.xxd.converter.supplier.thermo.cmbx.feature"
+            kind="converter"
+            license="Converter License Terms"
+            name="Thermo Chromeleon Container"
+            provider="Lablicate"
+            summary="Free extension exclusively for OpenChrom®"
+            icon="icons/32x32/Thermo.png">
+      </pluginDescriptor>
+
+      <pluginDescriptor
+            categoryId="com.lablicate.openchrom.converters.proprietary"
             description="Reads *.txt files."
             groupId="net.openchrom.csd.converter"
             id="net.openchrom.csd.converter.supplier.igraphx.feature"


### PR DESCRIPTION
It is actually just a ZIP container with some metadata and not a new converter file format. It contains files that we can parse like #823. Depends on https://github.com/eclipse-chemclipse/chemclipse/pull/2917 to work.