### PR TITLE
Fix "Peak Detector UI [Template]" checkbox columns clicks

### DIFF
--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/AbstractTemplateEditingSupport.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/AbstractTemplateEditingSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Lablicate GmbH.
+ * Copyright (c) 2022, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -49,7 +49,9 @@ public abstract class AbstractTemplateEditingSupport extends EditingSupport {
 		this.column = column;
 		EnumLabelProvider enumLabelProvider = new EnumLabelProvider();
 
-		if(column.equals(AbstractTemplateLabelProvider.OPTIMIZE_RANGE)) {
+		if(column.equals(AbstractTemplateLabelProvider.OPTIMIZE_RANGE) //
+				|| column.equals(AbstractTemplateLabelProvider.AUTO_ADJUST_SCAN_RANGE) //
+				|| column.equals(AbstractTemplateLabelProvider.AUTO_ADJUST_DETECTOR_RANGE)) {
 			this.cellEditor = new CheckboxCellEditor(tableViewer.getTable());
 		} else if(column.equals(AbstractTemplateLabelProvider.PEAK_TYPE)) {
 			ComboBoxViewerCellEditor editor = new ComboBoxViewerCellEditor((Composite)tableViewer.getControl());


### PR DESCRIPTION
Steps:

* Open a chromatogram
* Run "Peak Detector UI [Template]"
* In the opened dialog add a row
* The table has columns "Auto Adjust Scan Range" and "Auto Adjust Detector Range"
* Click any of the checkboxes - in the error log there is:
```
Fix java.lang.ClassCastException: class java.lang.String cannot be cast
to class java.lang.Boolean (java.lang.String and java.lang.Boolean are
in module java.base of loader 'bootstrap')
	at net.openchrom.xxd.process.supplier.templates.ui.internal.provider.PeakDetectorEditingSupport.setValue(PeakDetectorEditingSupport.java:98)
	at org.eclipse.jface.viewers.EditingSupport.saveCellEditorValue(EditingSupport.java:115)
	at org.eclipse.jface.viewers.ColumnViewerEditor.saveEditorValue(ColumnViewerEditor.java:444)
	at org.eclipse.jface.viewers.ColumnViewerEditor.applyEditorValue(ColumnViewerEditor.java:312)
	at org.eclipse.jface.viewers.ColumnViewerEditor.handleEditorActivationEvent(ColumnViewerEditor.java:427)
	at org.eclipse.jface.viewers.ColumnViewer.triggerEditorActivationEvent(ColumnViewer.java:680)
	at org.eclipse.jface.viewers.ColumnViewer.handleMouseDown(ColumnViewer.java:655)
	at org.eclipse.jface.viewers.ColumnViewer$1.mouseDown(ColumnViewer.java:111)
	at org.eclipse.swt.widgets.TypedListener.handleEvent(TypedListener.java:234)
```

Treat the 2 columns properly as needing CheckboxCellEditor.