### PR TITLE
Fix assertion problems in PeakStandardsAssigner/References

### DIFF
--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/StandardsAssignerListUI.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/StandardsAssignerListUI.java
@@ -18,7 +18,6 @@ import org.eclipse.chemclipse.support.ui.provider.ListContentProvider;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.widgets.Composite;
 
-import net.openchrom.xxd.process.supplier.templates.ui.internal.provider.AbstractTemplateLabelProvider;
 import net.openchrom.xxd.process.supplier.templates.ui.internal.provider.StandardsAssignerComparator;
 import net.openchrom.xxd.process.supplier.templates.ui.internal.provider.StandardsAssignerEditingSupport;
 import net.openchrom.xxd.process.supplier.templates.ui.internal.provider.StandardsAssignerFilter;
@@ -62,7 +61,7 @@ public class StandardsAssignerListUI extends AbstractTemplateListUI {
 		for(int i = 0; i < tableViewerColumns.size(); i++) {
 			TableViewerColumn tableViewerColumn = tableViewerColumns.get(i);
 			String label = tableViewerColumn.getColumn().getText();
-			if(!label.equals(AbstractTemplateLabelProvider.NAME)) {
+			if(!label.equals(StandardsAssignerLabelProvider.NAME_ISTD)) {
 				tableViewerColumn.setEditingSupport(new StandardsAssignerEditingSupport(this, label));
 			}
 		}

--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/StandardsReferencerListUI.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/swt/StandardsReferencerListUI.java
@@ -18,7 +18,6 @@ import org.eclipse.chemclipse.support.ui.provider.ListContentProvider;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.widgets.Composite;
 
-import net.openchrom.xxd.process.supplier.templates.ui.internal.provider.AbstractTemplateLabelProvider;
 import net.openchrom.xxd.process.supplier.templates.ui.internal.provider.StandardsReferencerComparator;
 import net.openchrom.xxd.process.supplier.templates.ui.internal.provider.StandardsReferencerEditingSupport;
 import net.openchrom.xxd.process.supplier.templates.ui.internal.provider.StandardsReferencerFilter;
@@ -62,7 +61,7 @@ public class StandardsReferencerListUI extends AbstractTemplateListUI {
 		for(int i = 0; i < tableViewerColumns.size(); i++) {
 			TableViewerColumn tableViewerColumn = tableViewerColumns.get(i);
 			String label = tableViewerColumn.getColumn().getText();
-			if(!label.equals(AbstractTemplateLabelProvider.NAME)) {
+			if(!label.equals(StandardsReferencerLabelProvider.NAME_ISTD)) {
 				tableViewerColumn.setEditingSupport(new StandardsReferencerEditingSupport(this, label));
 			}
 		}


### PR DESCRIPTION
Adding row to the table causes:
```
org.eclipse.core.runtime.AssertionFailedException: assertion failed:
	at org.eclipse.core.runtime.Assert.isTrue(Assert.java:121)
	at org.eclipse.core.runtime.Assert.isTrue(Assert.java:106)
	at org.eclipse.jface.viewers.TextCellEditor.doSetValue(TextCellEditor.java:225)
	at org.eclipse.jface.viewers.CellEditor.setValue(CellEditor.java:853)
	at org.eclipse.jface.viewers.EditingSupport.initializeCellEditorValue(EditingSupport.java:102)
	at org.eclipse.jface.viewers.ColumnViewerEditor.activateCellEditor(ColumnViewerEditor.java:203)
	at org.eclipse.jface.viewers.ColumnViewerEditor.handleEditorActivationEvent(ColumnViewerEditor.java:433)
	at org.eclipse.jface.viewers.ColumnViewer.triggerEditorActivationEvent(ColumnViewer.java:680)
	at org.eclipse.jface.viewers.ColumnViewer.handleMouseDown(ColumnViewer.java:655)
	at org.eclipse.jface.viewers.ColumnViewer$1.mouseDown(ColumnViewer.java:111)
	at org.eclipse.swt.widgets.TypedListener.handleEvent(TypedListener.java:234)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5845)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1656)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:5060)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4497)
	at org.eclipse.jface.window.Window.runEventLoop(Window.java:819)
	at org.eclipse.jface.window.Window.open(Window.java:799)
	at org.eclipse.chemclipse.ux.extension.ui.methods.SettingsWizard.openEditPreferencesWizard(SettingsWizard.java:67)
	at org.eclipse.chemclipse.ux.extension.ui.methods.SettingsWizard.getSettings(SettingsWizard.java:127)
```

This is due to the fact that non-existing column was filtered so editing support was added when it shouldn't.