### PR TITLE
Prevent assertion problems in EditingSupport instances

### DIFF
--- a/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/NameReplacementsEditingSupport.java
+++ b/openchrom/plugins/net.openchrom.xxd.process.supplier.templates.ui/src/net/openchrom/xxd/process/supplier/templates/ui/internal/provider/NameReplacementsEditingSupport.java
@@ -57,7 +57,8 @@ public class NameReplacementsEditingSupport extends EditingSupport {
 					return setting.getSynonym();
 			}
 		}
-		return false;
+		// only TextCellEditor thus "" to match type
+		return "";
 	}
 
 	@Override


### PR DESCRIPTION
For non-explicitly handled columns the type returned by getValue should match the cell editor type.