### PR TITLE
Fix p2 repo references to 2026-06

### DIFF
--- a/openchrom/sites/openchrom/category.xml
+++ b/openchrom/sites/openchrom/category.xml
@@ -8,8 +8,8 @@
          Update site for the OpenChrom platform.
       </description>
    </category-def>
-   <repository-reference location="https://download.eclipse.org/releases/2026-03/" enabled="true" />
-   <repository-reference location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-03" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/releases/2026-06/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06" enabled="true" />
    <repository-reference location="https://download.eclipse.org/nebula/updates/release/3.3.0/" enabled="true" />
    <repository-reference location="https://bundles.openchrom.net/3rdparty" enabled="true" />
 </site>


### PR DESCRIPTION
Missed during the switch of target platform.
Reduces Platform bits being mirrored in the openchrom repository.