### PR TITLE
Fix volatile application name

### DIFF
--- a/openchrom/plugins/net.openchrom.rcp.compilation.community.ui/plugin.xml
+++ b/openchrom/plugins/net.openchrom.rcp.compilation.community.ui/plugin.xml
@@ -20,7 +20,7 @@
          </property>
          <property
                name="appName"
-               value="OpenChrom (Hillenkamp)">
+               value="OpenChrom">
          </property>
          <property
                name="applicationXMI"


### PR DESCRIPTION
`qdbus6 org.kde.KWin /KWin queryWindowInfo` revealed the window manager class to be `OpenChrom (Hillenkamp)` which is unfortunate as it requires an update every major release which I will likely forget about. See https://github.com/flathub/com.lablicate.OpenChrom/pull/133 for example.

This changes it to just `OpenChrom` while keeping all the other labels to OpenChrom + code name like before. This also unmangles version and application.