### PR TITLE
Improve GAML detection performance

### DIFF
--- a/openchrom/plugins/net.openchrom.csd.converter.supplier.gaml/src/net/openchrom/csd/converter/supplier/gaml/converter/FileContentMatcher.java
+++ b/openchrom/plugins/net.openchrom.csd.converter.supplier.gaml/src/net/openchrom/csd/converter/supplier/gaml/converter/FileContentMatcher.java
@@ -13,15 +13,15 @@
 package net.openchrom.csd.converter.supplier.gaml.converter;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 
 import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
 
 import net.openchrom.xxd.converter.supplier.gaml.io.Reader;
 
@@ -30,39 +30,42 @@ public class FileContentMatcher extends AbstractFileContentMatcher {
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+		xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+		xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+		xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 
-			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-			Document document = documentBuilder.parse(file);
+		try (InputStream fileInputStream = new FileInputStream(file)) {
+			XMLStreamReader reader = xmlInputFactory.createXMLStreamReader(fileInputStream);
 
-			NodeList root = document.getElementsByTagName(Reader.NODE_GAML);
-			if(root.getLength() != 1) {
-				return false;
-			}
+			boolean foundGaml = false;
+			boolean isChromatography = false;
+			boolean otherTechnique = false;
 
-			NodeList experimentsList = document.getElementsByTagName("experiment");
-			for(int e = 0; e < experimentsList.getLength(); e++) {
-				Element experimentElem = (Element)experimentsList.item(e);
+			int events = 0;
 
-				NodeList traceList = experimentElem.getElementsByTagName("trace");
-				if(traceList.getLength() != 1) {
-					return false;
-				}
-				for(int t = 0; t < traceList.getLength(); t++) {
-					Element traceElement = (Element)traceList.item(t);
-					String technique = traceElement.getAttribute("technique");
-					if(technique != null && "CHROM".equalsIgnoreCase(technique.trim())) {
-						return true;
+			while(reader.hasNext() && events < 100000) {
+				int event = reader.next();
+				if(event == XMLStreamConstants.START_ELEMENT) {
+					String localName = reader.getLocalName();
+					if(Reader.NODE_GAML.equals(localName)) {
+						foundGaml = true;
+					}
+					if("trace".equals(localName)) {
+						String technique = reader.getAttributeValue(null, "technique");
+						if(technique != null) {
+							if("CHROM".equalsIgnoreCase(technique.trim())) {
+								isChromatography = true;
+							} else {
+								otherTechnique = true;
+							}
+						}
 					}
 				}
+				events++;
 			}
-		} catch(Exception ex) {
+			return foundGaml && isChromatography && !otherTechnique;
+		} catch(Exception _) {
 			// fail silently
 		}
 		return false;

--- a/openchrom/plugins/net.openchrom.fsd.converter.supplier.gaml/src/net/openchrom/fsd/converter/supplier/gaml/converter/FileContentMatcherSpectrum.java
+++ b/openchrom/plugins/net.openchrom.fsd.converter.supplier.gaml/src/net/openchrom/fsd/converter/supplier/gaml/converter/FileContentMatcherSpectrum.java
@@ -13,15 +13,15 @@
 package net.openchrom.fsd.converter.supplier.gaml.converter;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 
 import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
 
 import net.openchrom.xxd.converter.supplier.gaml.io.Reader;
 
@@ -30,39 +30,37 @@ public class FileContentMatcherSpectrum extends AbstractFileContentMatcher {
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+		xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+		xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+		xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 
-			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-			Document document = documentBuilder.parse(file);
+		try (InputStream fileInputStream = new FileInputStream(file)) {
+			XMLStreamReader reader = xmlInputFactory.createXMLStreamReader(fileInputStream);
 
-			NodeList root = document.getElementsByTagName(Reader.NODE_GAML);
-			if(root.getLength() != 1) {
-				return false;
-			}
+			boolean foundGaml = false;
+			boolean isFluorescence = false;
 
-			NodeList experimentsList = document.getElementsByTagName("experiment");
-			for(int e = 0; e < experimentsList.getLength(); e++) {
-				Element experimentElement = (Element)experimentsList.item(e);
+			int events = 0;
 
-				NodeList traceList = experimentElement.getElementsByTagName("trace");
-				if(traceList.getLength() != 1) {
-					return false;
-				}
-				for(int t = 0; t < traceList.getLength(); t++) {
-					Element traceElement = (Element)traceList.item(t);
-					String technique = traceElement.getAttribute("technique");
-					if(technique != null && "FLUOR".equalsIgnoreCase(technique.trim())) {
-						return true;
+			while(reader.hasNext() && events < 1000) {
+				int event = reader.next();
+				if(event == XMLStreamConstants.START_ELEMENT) {
+					String localName = reader.getLocalName();
+					if(Reader.NODE_GAML.equals(localName)) {
+						foundGaml = true;
+					}
+					if("trace".equals(localName)) {
+						String technique = reader.getAttributeValue(null, "technique");
+						if(technique != null && "FLUOR".equalsIgnoreCase(technique.trim())) {
+							isFluorescence = true;
+						}
 					}
 				}
+				events++;
 			}
-		} catch(Exception ex) {
+			return foundGaml && isFluorescence;
+		} catch(Exception _) {
 			// fail silently
 		}
 		return false;

--- a/openchrom/plugins/net.openchrom.msd.converter.supplier.gaml/src/net/openchrom/msd/converter/supplier/gaml/converter/FileContentMatcher.java
+++ b/openchrom/plugins/net.openchrom.msd.converter.supplier.gaml/src/net/openchrom/msd/converter/supplier/gaml/converter/FileContentMatcher.java
@@ -13,15 +13,15 @@
 package net.openchrom.msd.converter.supplier.gaml.converter;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 
 import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
 
 import net.openchrom.xxd.converter.supplier.gaml.io.Reader;
 
@@ -30,48 +30,40 @@ public class FileContentMatcher extends AbstractFileContentMatcher {
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+		xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+		xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+		xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 
-			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-			Document document = documentBuilder.parse(file);
+		try (InputStream fileInputStream = new FileInputStream(file)) {
+			XMLStreamReader reader = xmlInputFactory.createXMLStreamReader(fileInputStream);
 
-			NodeList root = document.getElementsByTagName(Reader.NODE_GAML);
-			if(root.getLength() != 1) {
-				return false;
-			}
+			boolean foundGaml = false;
+			boolean isChromatography = false;
+			boolean isMassSpectrometry = false;
 
-			NodeList experimentsList = document.getElementsByTagName("experiment");
-			for(int e = 0; e < experimentsList.getLength(); e++) {
-				Element experimentElement = (Element)experimentsList.item(e);
-				NodeList traceList = experimentElement.getElementsByTagName("trace");
+			int events = 0;
 
-				boolean chromatography = false;
-				boolean msd = false;
-
-				for(int t = 0; t < traceList.getLength(); t++) {
-					Element traceElement = (Element)traceList.item(t);
-					String technique = traceElement.getAttribute("technique");
-					if(technique == null) {
-						continue;
+			while(reader.hasNext() && events < 1000) {
+				int event = reader.next();
+				if(event == XMLStreamConstants.START_ELEMENT) {
+					String localName = reader.getLocalName();
+					if(Reader.NODE_GAML.equals(localName)) {
+						foundGaml = true;
 					}
-					if("CHROM".equalsIgnoreCase(technique.trim())) {
-						chromatography = true;
-					} else if("MS".equalsIgnoreCase(technique.trim())) {
-						msd = true;
+					if("trace".equals(localName)) {
+						String technique = reader.getAttributeValue(null, "technique");
+						if(technique != null && "CHROM".equalsIgnoreCase(technique.trim())) {
+							isChromatography = true;
+						} else if(technique != null && "MS".equalsIgnoreCase(technique.trim())) {
+							isMassSpectrometry = true;
+						}
 					}
 				}
-
-				if(chromatography && msd) {
-					return true;
-				}
+				events++;
 			}
-		} catch(Exception ex) {
+			return foundGaml && isChromatography && isMassSpectrometry;
+		} catch(Exception _) {
 			// fail silently
 		}
 		return false;

--- a/openchrom/plugins/net.openchrom.nmr.converter.supplier.gaml/src/net/openchrom/nmr/converter/supplier/gaml/converter/FileContentMatcher.java
+++ b/openchrom/plugins/net.openchrom.nmr.converter.supplier.gaml/src/net/openchrom/nmr/converter/supplier/gaml/converter/FileContentMatcher.java
@@ -13,53 +13,45 @@
 package net.openchrom.nmr.converter.supplier.gaml.converter;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 
 import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-
-import net.openchrom.xxd.converter.supplier.gaml.io.Reader;
 
 public class FileContentMatcher extends AbstractFileContentMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+		xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+		xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+		xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 
-			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-			Document document = documentBuilder.parse(file);
+		try (InputStream fileInputStream = new FileInputStream(file)) {
+			XMLStreamReader reader = xmlInputFactory.createXMLStreamReader(fileInputStream);
 
-			NodeList root = document.getElementsByTagName(Reader.NODE_GAML);
-			if(root.getLength() != 1) {
-				return false;
-			}
+			int events = 0;
 
-			NodeList experimentsList = document.getElementsByTagName("experiment");
-			for(int e = 0; e < experimentsList.getLength(); e++) {
-				Element experimentElement = (Element)experimentsList.item(e);
-
-				NodeList traceList = experimentElement.getElementsByTagName("trace");
-				for(int t = 0; t < traceList.getLength(); t++) {
-					Element traceElement = (Element)traceList.item(t);
-					String technique = traceElement.getAttribute("technique");
-					if(technique != null && "NMR".equalsIgnoreCase(technique.trim())) {
-						return true;
+			while(reader.hasNext() && events < 10000) {
+				int event = reader.next();
+				if(event == XMLStreamConstants.START_ELEMENT) {
+					String localName = reader.getLocalName();
+					if("trace".equals(localName)) {
+						String technique = reader.getAttributeValue(null, "technique");
+						if(technique != null && "NMR".equalsIgnoreCase(technique.trim())) {
+							return true;
+						}
 					}
 				}
+				events++;
 			}
-		} catch(Exception ex) {
+		} catch(Exception _) {
 			// fail silently
 		}
 		return false;

--- a/openchrom/plugins/net.openchrom.vsd.converter.supplier.gaml/src/net/openchrom/vsd/converter/supplier/gaml/converter/FileContentMatcher.java
+++ b/openchrom/plugins/net.openchrom.vsd.converter.supplier.gaml/src/net/openchrom/vsd/converter/supplier/gaml/converter/FileContentMatcher.java
@@ -14,62 +14,51 @@
 package net.openchrom.vsd.converter.supplier.gaml.converter;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 
 import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-
-import net.openchrom.xxd.converter.supplier.gaml.io.Reader;
 
 public class FileContentMatcher extends AbstractFileContentMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+		xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+		xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+		xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 
-			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-			Document document = documentBuilder.parse(file);
+		try (InputStream fileInputStream = new FileInputStream(file)) {
+			XMLStreamReader reader = xmlInputFactory.createXMLStreamReader(fileInputStream);
 
-			NodeList root = document.getElementsByTagName(Reader.NODE_GAML);
-			if(root.getLength() != 1) {
-				return false;
-			}
+			int events = 0;
 
-			NodeList experimentsList = document.getElementsByTagName("experiment");
-			for(int e = 0; e < experimentsList.getLength(); e++) {
-				Element experimentElement = (Element)experimentsList.item(e);
-
-				NodeList traceList = experimentElement.getElementsByTagName("trace");
-				for(int t = 0; t < traceList.getLength(); t++) {
-					Element traceElement = (Element)traceList.item(t);
-					String technique = traceElement.getAttribute("technique");
-					if(technique == null) {
-						continue;
-					}
-					if("IR".equalsIgnoreCase(technique.trim())) {
-						return true;
-					}
-					if("NIR".equalsIgnoreCase(technique.trim())) {
-						return true;
-					}
-					if("RAMAN".equalsIgnoreCase(technique.trim())) {
-						return true;
+			while(reader.hasNext() && events < 1000) {
+				int event = reader.next();
+				if(event == XMLStreamConstants.START_ELEMENT) {
+					String localName = reader.getLocalName();
+					if("trace".equals(localName)) {
+						String technique = reader.getAttributeValue(null, "technique");
+						if(technique != null) {
+							if("IR".equalsIgnoreCase(technique.trim())) {
+								return true;
+							} else if("NIR".equalsIgnoreCase(technique.trim())) {
+								return true;
+							} else if("RAMAN".equalsIgnoreCase(technique.trim())) {
+								return true;
+							}
+						}
 					}
 				}
+				events++;
 			}
-		} catch(Exception ex) {
+		} catch(Exception _) {
 			// fail silently
 		}
 		return false;

--- a/openchrom/plugins/net.openchrom.wsd.converter.supplier.gaml/src/net/openchrom/wsd/converter/supplier/gaml/converter/FileContentMatcherChromatogram.java
+++ b/openchrom/plugins/net.openchrom.wsd.converter.supplier.gaml/src/net/openchrom/wsd/converter/supplier/gaml/converter/FileContentMatcherChromatogram.java
@@ -13,55 +13,47 @@
 package net.openchrom.wsd.converter.supplier.gaml.converter;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 
 import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-
-import net.openchrom.xxd.converter.supplier.gaml.io.Reader;
 
 public class FileContentMatcherChromatogram extends AbstractFileContentMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+		xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+		xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+		xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 
-			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-			Document document = documentBuilder.parse(file);
+		try (InputStream fileInputStream = new FileInputStream(file)) {
+			XMLStreamReader reader = xmlInputFactory.createXMLStreamReader(fileInputStream);
 
-			NodeList root = document.getElementsByTagName(Reader.NODE_GAML);
-			if(root.getLength() != 1) {
-				return false;
-			}
+			int events = 0;
 
-			NodeList experimentsList = document.getElementsByTagName("experiment");
-			for(int e = 0; e < experimentsList.getLength(); e++) {
-				Element experimentElem = (Element)experimentsList.item(e);
-				NodeList traceList = experimentElem.getElementsByTagName("trace");
-				for(int t = 0; t < traceList.getLength(); t++) {
-					Element traceElement = (Element)traceList.item(t);
-					String technique = traceElement.getAttribute("technique");
-					if(technique != null && "PDA".equalsIgnoreCase(technique.trim())) {
-						return true;
+			while(reader.hasNext() && events < 100000) {
+				int event = reader.next();
+				if(event == XMLStreamConstants.START_ELEMENT) {
+					String localName = reader.getLocalName();
+					if("trace".equals(localName)) {
+						String technique = reader.getAttributeValue(null, "technique");
+						if(technique != null && "PDA".equalsIgnoreCase(technique.trim())) {
+							return true;
+						}
 					}
 				}
+				events++;
 			}
-		} catch(Exception ex) {
+		} catch(Exception _) {
 			// fail silently
 		}
-
 		return false;
 	}
 }

--- a/openchrom/plugins/net.openchrom.wsd.converter.supplier.gaml/src/net/openchrom/wsd/converter/supplier/gaml/converter/FileContentMatcherSpectrum.java
+++ b/openchrom/plugins/net.openchrom.wsd.converter.supplier.gaml/src/net/openchrom/wsd/converter/supplier/gaml/converter/FileContentMatcherSpectrum.java
@@ -13,54 +13,47 @@
 package net.openchrom.wsd.converter.supplier.gaml.converter;
 
 import java.io.File;
-import java.util.List;
+import java.io.FileInputStream;
+import java.io.InputStream;
 
 import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
 
 import org.eclipse.chemclipse.converter.core.AbstractFileContentMatcher;
-import org.w3c.dom.Document;
-import org.w3c.dom.NodeList;
-
-import net.openchrom.xxd.converter.supplier.gaml.io.Reader;
-import net.openchrom.xxd.converter.supplier.gaml.v120.model.GAML;
-import net.openchrom.xxd.converter.supplier.gaml.v120.model.ObjectFactory;
-import net.openchrom.xxd.converter.supplier.gaml.v120.model.Technique;
-import net.openchrom.xxd.converter.supplier.gaml.v120.model.Trace;
-
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.Unmarshaller;
 
 public class FileContentMatcherSpectrum extends AbstractFileContentMatcher {
 
 	@Override
 	public boolean checkFileFormat(File file) {
 
-		boolean isValidFormat = false;
-		try {
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-			documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+		xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+		xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+		xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 
-			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-			Document document = documentBuilder.parse(file);
-			NodeList nodeList = document.getElementsByTagName(Reader.NODE_GAML);
+		try (InputStream fileInputStream = new FileInputStream(file)) {
+			XMLStreamReader reader = xmlInputFactory.createXMLStreamReader(fileInputStream);
 
-			JAXBContext jaxbContext = JAXBContext.newInstance(ObjectFactory.class);
-			Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
-			GAML gaml = (GAML)unmarshaller.unmarshal(nodeList.item(0));
-			List<Trace> traces = gaml.getExperiment().get(0).getTrace();
-			Technique technique = traces.get(0).getTechnique();
-			if(technique == Technique.UVVIS) {
-				isValidFormat = true;
+			int events = 0;
+
+			while(reader.hasNext() && events < 1000) {
+				int event = reader.next();
+				if(event == XMLStreamConstants.START_ELEMENT) {
+					String localName = reader.getLocalName();
+					if("trace".equals(localName)) {
+						String technique = reader.getAttributeValue(null, "technique");
+						if(technique != null && "UVVIS".equalsIgnoreCase(technique.trim())) {
+							return true;
+						}
+					}
+				}
+				events++;
 			}
-		} catch(Exception e) {
+		} catch(Exception _) {
 			// fail silently
 		}
-		return isValidFormat;
+		return false;
 	}
 }


### PR DESCRIPTION
Same idea as in https://github.com/eclipse-chemclipse/chemclipse/pull/3053 but a bit more unfortunate as large GAML files with multiple techniques have their definitions mid stream which means more events get parsed.