### PR TITLE
Don't warn about expected data size diffs in .ab1

### DIFF
--- a/openchrom/plugins/net.openchrom.wsd.converter.supplier.abif/src/net/openchrom/wsd/converter/supplier/abif/io/ChromatogramReader.java
+++ b/openchrom/plugins/net.openchrom.wsd.converter.supplier.abif/src/net/openchrom/wsd/converter/supplier/abif/io/ChromatogramReader.java
@@ -117,7 +117,6 @@ public class ChromatogramReader extends AbstractChromatogramWSDReader {
 		in.resetPosition();
 		int directoryDataOffset = dataOffset;
 		in.seek(directoryDataOffset);
-		int position = in.getPosition();
 		// temporary data storage as we need to reorder later
 		int scans = 0;
 		short downSamplingFactor = 0;
@@ -160,7 +159,7 @@ public class ChromatogramReader extends AbstractChromatogramWSDReader {
 						in.skipBytes(4);
 						continue;
 					}
-					position = in.getPosition();
+					int position = in.getPosition();
 					in.resetPosition();
 					in.seek(dataOffset);
 					// C-style string (null terminated).

--- a/openchrom/plugins/net.openchrom.wsd.converter.supplier.abif/src/net/openchrom/wsd/converter/supplier/abif/io/ChromatogramReader.java
+++ b/openchrom/plugins/net.openchrom.wsd.converter.supplier.abif/src/net/openchrom/wsd/converter/supplier/abif/io/ChromatogramReader.java
@@ -243,7 +243,7 @@ public class ChromatogramReader extends AbstractChromatogramWSDReader {
 				short signal = channel[s];
 				float abundance = signal;
 				if(downSamplingFactor > 0) {
-					abundance = signal / downSamplingFactor;
+					abundance = signal / (float)downSamplingFactor;
 				}
 				scanSignal.setAbsorbance(abundance);
 				scan.addScanSignal(scanSignal);

--- a/openchrom/plugins/net.openchrom.wsd.converter.supplier.abif/src/net/openchrom/wsd/converter/supplier/abif/io/ChromatogramReader.java
+++ b/openchrom/plugins/net.openchrom.wsd.converter.supplier.abif/src/net/openchrom/wsd/converter/supplier/abif/io/ChromatogramReader.java
@@ -107,8 +107,8 @@ public class ChromatogramReader extends AbstractChromatogramWSDReader {
 		if(!tagName.equals("tdir")) {
 			throw new FileIsNotReadableException("Can't find ABIF directory entry.");
 		}
-		int expectedDataSize = elements * elementSize; // legacy libraries may have reserved additional space in the directory
-		if(dataSize != expectedDataSize) {
+		int expectedDataSize = elements * elementSize;
+		if(dataSize < expectedDataSize) { // legacy libraries may have reserved additional space in the directory
 			logger.warn("Invalid data size " + dataSize + " in ABIF file detected. Expected " + expectedDataSize + ".");
 		}
 		/*


### PR DESCRIPTION
as these trailing/unused 0 byte arrays are not a problem. Only warn when there is not enough data and the parser will actually fail.