### PR TITLE
Enable native access

### DIFF
--- a/openchrom/products/net.openchrom.rcp.compilation.community.product/openchrom.compilation.community.product
+++ b/openchrom/products/net.openchrom.rcp.compilation.community.product/openchrom.compilation.community.product
@@ -33,6 +33,7 @@
 -Dp2.trustedAuthorities=https://converter.openchrom.net,https://plugins.openchrom.net,https://update.openchrom.net,https://plugins.lablicate.com
 -XX:+UseG1GC
 -XX:+UseStringDeduplication
+--enable-native-access=ALL-UNNAMED
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread
       </vmArgsMac>


### PR DESCRIPTION
Silences warnings on startup like
```
WARNING: A restricted method in java.lang.Runtime has been called
WARNING: java.lang.Runtime::load has been called by
org.eclipse.equinox.launcher.JNIBridge in an unnamed module
(file:/home/akurtakov/work/chemclipse/.metadata/.plugins/org.eclipse.pde.core/.bundle_pool/plugins/org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for
callers in this module
WARNING: Restricted methods will be blocked in a future release unless
native access is enabled
```
caused by https://openjdk.org/jeps/472