### PR TITLE
Skip local p2 repositories when checking for updates

### DIFF
--- a/openchrom/plugins/net.openchrom.installer.ui/src/net/openchrom/installer/ui/handlers/CheckForUpdatesHander.java
+++ b/openchrom/plugins/net.openchrom.installer.ui/src/net/openchrom/installer/ui/handlers/CheckForUpdatesHander.java
@@ -140,6 +140,11 @@ public class CheckForUpdatesHander {
 		URI[] known = metaManager.getKnownRepositories(IRepositoryManager.REPOSITORIES_ALL);
 		Set<URI> newUris = new HashSet<>();
 		for(URI uri : known) {
+			String scheme = uri.getScheme();
+			if(!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+				// Only the online update sites can offer a new release.
+				continue;
+			}
 			URI newUri = replaceVersion(uri, toVersion.toString());
 			newUris.add(newUri);
 		}


### PR DESCRIPTION
Local repositories (e.g. installation directory itself) are not supposed to deliver newer release, so keep them out of the
provisioning context.

Fixes https://github.com/OpenChrom/openchrom/issues/916 as https urls should not contain spaces like windows paths can.